### PR TITLE
 PGMS_240820_리코쳇로봇

### DIFF
--- a/hoo/august/PGMS_240820_리코쳇로봇.java
+++ b/hoo/august/PGMS_240820_리코쳇로봇.java
@@ -1,0 +1,91 @@
+package august;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class PGMS_240820_리코쳇로봇 {
+
+    class Mover {
+        int row;
+        int col;
+        int moves;  // 움직인 횟수
+
+        public Mover(int row, int col, int moves) {
+            this.row = row;
+            this.col = col;
+            this.moves = moves;
+        }
+
+        @Override
+        public String toString() { return this.row + " " + this.col + " " + this.moves; }
+    }
+
+    int[] dirRow = new int[] {-1, 1, 0, 0}; // 상 하 좌 우
+    int[] dirCol = new int[] {0, 0, -1, 1};
+    int R, C;  // 보드의 높이, 너비
+    int[] goal; // 목표 지점의 좌표
+
+    public int solution(String[] board) {
+        Mover initMover = init(board);
+        int answer = bfs(board, initMover);
+
+        return answer;
+    }
+
+    Mover init(String[] board) {
+        Mover initMover = null;
+
+        R = board.length;
+        C = board[0].length();
+        goal = new int[2];
+        String nowPoint;
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                nowPoint = String.valueOf(board[i].charAt(j));
+                if (nowPoint.equals("R")) initMover = new Mover(i, j, 0);
+                else if (nowPoint.equals("G")) goal = new int[] {i, j};
+            }
+        }
+
+        return initMover;
+    }
+
+    int bfs(String[] board, Mover initMover) {
+        int answer = -1;
+
+        boolean[][] isVisited = new boolean[R][C];
+        Queue<Mover> q = new ArrayDeque<>();
+        q.offer(initMover);
+        isVisited[initMover.row][initMover.col] = true;
+
+        while (!q.isEmpty()) {
+            Mover now = q.poll();
+            if (now.row == goal[0] && now.col == goal[1]) return now.moves; // 목표에 도착 시 움직인 횟수 리턴 후 종료
+
+            int nextRow, nextCol;
+            for (int d = 0; d < 4; d++) {   // 4방향 모두에 대해
+                nextRow = now.row;
+                nextCol = now.col;
+                while (true) {  // 벽에 부딪히거나 장애물에 부딪힐 때까지 이동
+                    nextRow += dirRow[d];
+                    nextCol += dirCol[d];
+                    if (isOuted(nextRow, nextCol) || String.valueOf(board[nextRow].charAt(nextCol)).equals("D")) break;
+                }
+                nextRow -= dirRow[d];   // 미끄러짐을 중단한 시점은 벽이거나 장애물에 도달한 경우이므로 한 칸 롤백
+                nextCol -= dirCol[d];
+
+                if (isVisited[nextRow][nextCol]) continue;  // 이미 방문한 곳이면 건너 뜀
+                q.offer(new Mover(nextRow, nextCol, now.moves+1));
+                isVisited[nextRow][nextCol] = true;
+            }
+        }
+
+        return answer;
+    }
+
+    boolean isOuted(int row, int col) {
+        if ((0 <= row && row < R) && (0 <= col && col < C)) return false;
+        return true;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #5 

## 📝 문제 풀이 전략 및 실제 풀이 방법
보드가 나왔고, 최소 이동횟수를 카운트하는 문제였으므로 bfs로 접근했습니다. 전체적인 틀은 bfs 그 자체였으나 미끄러짐에 대한 추가 로직 구현이 필요했습니다. 가장 기초적인 bfs문제였다면 범위 밖으로 나가는 것, 장애물에 부딪히는 것을 이동이 불가하다고 판단했을 것입니다. 이 문제에서는 그 부분을 부딪힐 때까지 진행, 부딪히면 멈춘다고 설정해두었습니다.  
그 부분에 대한 해결을 위해 4방 탐색 시 한 방향에서 반복물을 통해 벽이나 장애물을 만날 때까지 이동을 수행해주고, 벽이나 장애물을 만난 후 반복문을 빠져나와 한 칸 롤백을 수행해주었습니다.(다른 수식으로 표현할 수 있을 지는 모르겠으나, 이 부분은 직관적으로 해결하고자 했습니다.)  
다른 문제에서 벽과 장애물에 대해 제한을 거는 것을 해당 문제에서는 다르게 사용해 색다른 문제였던 것 같습니다.

## 🧐 참고 사항

## 📄 Reference
