### PR TITLE
PGMS_240821_롤케이크 자르기

### DIFF
--- a/hoo/august/PGMS_240821_롤케이크자르기.java
+++ b/hoo/august/PGMS_240821_롤케이크자르기.java
@@ -1,0 +1,51 @@
+package august;
+
+public class PGMS_240821_롤케이크자르기 {
+
+    boolean[][] isUsed;
+    int[][] toppingCounts;    // 인덱스마다 사용된 토핑 종류 카운트하고 저장할 배열
+
+    public int solution(int[] topping) {
+        init(topping);
+
+        return countCase(topping);
+    }
+
+    void init(int[] topping) {
+        int l = topping.length;
+
+        isUsed = new boolean[2][10_001];   // 최대 10,000개의 토핑에 대해 사용여부 체크
+        toppingCounts = new int[2][l]; // 0: 앞에서 카운트한 경우, 1: 뒤에서 카운트한 경우
+        toppingCounts[0][0] = 1;
+        isUsed[0][topping[0]] = true;
+        toppingCounts[1][l-1] = 1;
+        isUsed[1][topping[l-1]] = true;
+
+        for (int i = 1; i < l; i++) {
+            checkTopping(topping, topping[i], i, 0);
+            checkTopping(topping, topping[l-i-1], l-i-1, 1);
+        }
+    }
+
+    void checkTopping(int[] topping, int nowTopping, int index, int mode) { // mode => 0: 정방향, 1: 역방향
+        int beforeIndex;
+        if (mode == 0) beforeIndex = index - 1;
+        else beforeIndex = index + 1;
+
+        if (isUsed[mode][nowTopping]) toppingCounts[mode][index] = toppingCounts[mode][beforeIndex];
+        else {
+            isUsed[mode][nowTopping] = true;
+            toppingCounts[mode][index] = toppingCounts[mode][beforeIndex] + 1;
+        }
+    }
+
+    int countCase(int[] topping) {
+        int answer = 0;
+        for (int i = 0; i < topping.length-1; i++) {
+            if (toppingCounts[0][i] == toppingCounts[1][i+1]) answer++;
+        }
+
+        return answer;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #8 

## 📝 문제 풀이 전략 및 실제 풀이 방법
두 명에 대해서만 공정한 지 판단하면 되므로, 인덱스 하나를 지정하여 그를 기점으로 비교를 해주면 된다고 생각했습니다. 하지만 N이 100만임을 고려하면 인덱스 지정에 사용될 반복문 안에서의 중첩 반복은 허용되지 않을 것 같았습니다. 그리하여 인덱스 별 누적 토핑 종류를 저장하여야겠다고 생각했고 그렇게 풀이했습니다.  
롤케이크를 잘랐을 때 자르기 이전까지의 누적 종류, 자른 이후의 누적 종류를 카운트해줘야 하는데 이마저도 중첩 반복을 하면 안됐습니다. 자르기 이전까지의 누적 종류는 단순히 반복문을 돌며 카운트해주면 됩니다. 하지만 자른 이후의 누적 종류는 자른 시점부터 생각하면 복잡합니다. 이 때문에 자른 이후의 누적 종류는 뒤에서부터 역으로 카운트해주어야겠다고 생각했습니다. 그렇게 한 번의 반복문 안에서 인덱스를 이용, 2차원 배열에 앞에서 부터 카운트 한 누적 종류는 0번 열에, 뒤에서부터 카운트 한 누적 종류는 1번 열에 저장해주었습니다.
이후에는 2차원 배열을 순회하며 자른 시점에서 누적 종류를 저장한 배열의 [0][i]과 [1][i+1]의 값을 비교하여 같으면 공정한 경우로 판단하는 방식으로 해결했습니다.

## 🧐 참고 사항
![image](https://github.com/user-attachments/assets/a81c305b-a9a8-4942-86cf-82031786182d)  
이게 제가 프로그래머스 문제를 선정하는 옵션인데요, 저는 여기서 lv2를 먼저 정복하고 lv3을 정복하는 방식으로 문제를 출제하겠습니다. 이건 그냥 궁금하실까봐 알려드리는 참고 사항입니다.

## 📄 Reference
