### PR TITLE
롤케이크 자르기

### DIFF
--- a/hyun/august/PGMS_132265_롤케이크자르기.java
+++ b/hyun/august/PGMS_132265_롤케이크자르기.java
@@ -1,0 +1,31 @@
+package implementation;
+
+// 각 조각에  동일한 가짓수의 토핑 = 공평
+import java.io.*;
+        import java.util.*;
+
+public class PGMS_132265_롤케이크자르기 {
+    public int solution(int[] topping) {
+        int answer = 0;
+        HashMap<Integer, Integer> right = new HashMap<>();
+        HashMap<Integer, Integer> left = new HashMap<>();
+
+        for(int su : topping){
+            if(right.containsKey(su)) right.put(su, right.get(su) + 1);
+            else right.put(su, 1);
+        }
+
+        for(int su : topping){
+            if(left.containsKey(su)) left.put(su, left.get(su) + 1);
+            else left.put(su, 1);
+
+            right.put(su, right.get(su) - 1);
+            if(right.get(su) == 0) right.remove(su);
+
+            if(left.size() == right.size()) answer++;
+
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#8 


## 📝 문제 풀이 전략 및 실제 풀이 방법
### 단순 구현 문제
- 토핑 배열은 10^6 이어서 2중 순회는 시간초과가 날 것 같았음
- 최대한 1번만 순회하자는 생각으로 아이디어를 구상함
- 특정 인덱스를 기준으로 왼쪽과 오른쪽 토핑의 갯수를 봐주면 된다고 생각함
- 따라서, 먼저 HashMap<토핑번호, 갯수> 을 left, right 이름으로 2개를 선언해준 후, right 에 모든 토핑들을 넣어줌
- 그 다음 1번더 모든 토핑들을 반복문으로 돌면서 right 에 있는 것을 한개씩 left 로 옮겨준 후, 공평하게 나눴는지 확인해줌 

## 🧐 참고 사항
갑자기 HashMap remove 하는 함수가 생각나지 않아 레퍼런스 뒤졌습니당
java.lang 패키지 안에 있더라고요~

## 📄 Reference
.
