### PR TITLE
PGMS_240822_광물 캐기

### DIFF
--- a/hoo/august/PGMS_240822_광물캐기.java
+++ b/hoo/august/PGMS_240822_광물캐기.java
@@ -1,0 +1,93 @@
+package august;
+
+public class PGMS_240822_광물캐기 {
+
+    public int solution(int[] picks, String[] minerals) {
+        int answer = 0;
+        int[] neededEnerge = calcBestCase(picks, minerals);
+        answer = findBestCase(picks, minerals, neededEnerge);
+
+        return answer;
+    }
+
+    int[] calcBestCase(int[] picks, String[] minerals) {    // 5개씩 끊어서 돌 곡괭이 기준 피로도 저장하는 함수
+        int picksCount = 0; // 곡괭이 개수만큼만 광물 캐는 데 사용 가능하므로 곡괭이 개수도 구해야 함.
+        for (int i = 0; i < picks.length; i++) picksCount += picks[i];
+        int dividedByFive = minerals.length%5 == 0 ? minerals.length/5 : minerals.length/5 + 1; // 우선 광물을 5개씩 끊었을 때 몇 칸이 될지 구함
+        dividedByFive = Math.min(dividedByFive, picksCount);    // 곡괭이 개수와 비교하여 둘 중 낮은 값으로 저장
+        int[] neededEnerge = new int[dividedByFive];
+
+        int energeIndex = 0;
+        int tempSum = 0;
+        for (int i = 0; i < Math.min(minerals.length, dividedByFive * 5); i++) { // 모든 광물 돌며(곡괭이 개수가 더 적으면 곡괭이 개수만큼만) 5개씩 끊은 광물에 필요한 피로도 저장하기
+            if (i != 0 && i%5 == 0) {
+                neededEnerge[energeIndex] = tempSum;
+                energeIndex++;
+                tempSum = 0;
+            }
+
+            switch (minerals[i]) {
+                case "diamond":
+                    tempSum += 25;
+                    break;
+                case "iron":
+                    tempSum += 5;
+                    break;
+                case "stone":
+                    tempSum += 1;
+                    break;
+            }
+        }
+        neededEnerge[energeIndex] = tempSum;    // 마지막 인덱스 피로도 저장
+
+        return neededEnerge;
+    }
+
+    int findBestCase(int[] picks, String[] minerals, int[] neededEnerge) {
+        int totalEnerge = 0;    // 다 캐는데 드는 피로도
+
+        PriorityQueue<int[]> pq = new PriorityQueue<>(new Comparator<int[]>() { // 피로도 큰 순, 인덱스와 함께 pq에 저장
+            @Override
+            public int compare(int[] o1, int[] o2) {
+                return o2[0] - o1[0];
+            }
+        });
+        for (int i = 0; i < neededEnerge.length; i++) pq.offer(new int[] {neededEnerge[i], i});
+
+        int pickIndex = 0;  // 곡괭이의 인덱스
+        int mineralStartIndex;
+        while (!pq.isEmpty()) { // 크기 순으로 저장한 피로도에 대해
+            int[] nowNeededEnerge = pq.poll();
+            while (picks[pickIndex] == 0) pickIndex++; // 곡괭이 다 썼으면 다음 곡괭이 사용
+
+            mineralStartIndex = nowNeededEnerge[1] * 5;    // 캐기 시작할 광물의 인덱스
+            totalEnerge += mineMineral(minerals, pickIndex, mineralStartIndex);
+            picks[pickIndex]--;
+        }
+
+        return totalEnerge;
+    }
+
+    int mineMineral(String[] minerals, int pickIndex, int mineralStartIndex) {
+        int energeSum = 0;
+
+        int[][] energeGraph = new int[][] {{1, 1, 1}, {5, 1, 1}, {25, 5, 1}};
+
+        for (int i = mineralStartIndex; i < Math.min(mineralStartIndex + 5, minerals.length); i++) { // 현재 곡괭이로 인덱스에 해당하는 광물들을 캠
+            switch (minerals[i]) {
+                case "diamond":
+                    energeSum += energeGraph[pickIndex][0];
+                    break;
+                case "iron":
+                    energeSum += energeGraph[pickIndex][1];
+                    break;
+                case "stone":
+                    energeSum += energeGraph[pickIndex][2];
+                    break;
+            }
+        }
+
+        return energeSum;
+    }
+
+}

--- a/hoo/august/PGMS_240822_광물캐기.java
+++ b/hoo/august/PGMS_240822_광물캐기.java
@@ -8,7 +8,7 @@ public class PGMS_240822_광물캐기 {
     public int solution(int[] picks, String[] minerals) {
         int answer = 0;
         int[] neededEnerge = calcNeededEnerge(picks, minerals);
-        answer = findBestCase(picks, minerals, neededEnerge);
+        answer = calcBestCase(picks, minerals, neededEnerge);
 
         return answer;
     }
@@ -46,7 +46,7 @@ public class PGMS_240822_광물캐기 {
         return neededEnerge;
     }
 
-    int findBestCase(int[] picks, String[] minerals, int[] neededEnerge) {
+    int calcBestCase(int[] picks, String[] minerals, int[] neededEnerge) {
         int totalEnerge = 0;    // 다 캐는데 드는 피로도
 
         PriorityQueue<int[]> pq = new PriorityQueue<>(new Comparator<int[]>() { // 피로도 큰 순, 인덱스와 함께 pq에 저장

--- a/hoo/august/PGMS_240822_광물캐기.java
+++ b/hoo/august/PGMS_240822_광물캐기.java
@@ -7,13 +7,13 @@ public class PGMS_240822_광물캐기 {
 
     public int solution(int[] picks, String[] minerals) {
         int answer = 0;
-        int[] neededEnerge = calcBestCase(picks, minerals);
+        int[] neededEnerge = calcNeededEnerge(picks, minerals);
         answer = findBestCase(picks, minerals, neededEnerge);
 
         return answer;
     }
 
-    int[] calcBestCase(int[] picks, String[] minerals) {    // 5개씩 끊어서 돌 곡괭이 기준 피로도 저장하는 함수
+    int[] calcNeededEnerge(int[] picks, String[] minerals) {    // 5개씩 끊어서 돌 곡괭이 기준 피로도 저장하는 함수
         int picksCount = 0; // 곡괭이 개수만큼만 광물 캐는 데 사용 가능하므로 곡괭이 개수도 구해야 함.
         for (int i = 0; i < picks.length; i++) picksCount += picks[i];
         int dividedByFive = minerals.length%5 == 0 ? minerals.length/5 : minerals.length/5 + 1; // 우선 광물을 5개씩 끊었을 때 몇 칸이 될지 구함

--- a/hoo/august/PGMS_240822_광물캐기.java
+++ b/hoo/august/PGMS_240822_광물캐기.java
@@ -1,5 +1,8 @@
 package august;
 
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
 public class PGMS_240822_광물캐기 {
 
     public int solution(int[] picks, String[] minerals) {


### PR DESCRIPTION
## 🔍 개요
+ #11 

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 처음 접근
 처음 생각한 풀이법은 곡괭이의 개수만큼 광물을 순서대로 나열하고 최소 값을 찾는 것이었습니다. 하지만 이 경우 최악의 경우의 수가 50P15 혹은 그 이상이므로, 말도 안되는 시간복잡도를 가질 것 같아 다른 방법을 생각하게 되었습니다.
+ 이후의 접근
 문제에서 광물은 순서대로 캐야하며, 곡괭이 당 5개의 광물을 캘 수 있다는 조건을 주었습니다. 이를 이용해 우선 광물을 5개씩 묶어 필요한 피로도를 계산하고 이용해야겠다는 생각을 하게 되었습니다. 이때 곡괭이 개수*5개 만큼만 광물을 캘 수 있으므로 이 부분도 고려하여 돌 곡괭이 기준 5개씩 묶음에 대한 피로도를 배열에 저장해주었습니다. 이렇게 생성된 피로도 배열은 최대 길이 10을 가집니다.  
50을 10으로 줄였으므로 이에 대해서 다시 곡괭이의 순열을 생각해보았습니다. 이는 10!=약 300만의 시간복잡도를 가지지만, 한 가지 경우를 위해 필요없는 300만가지의 경우를 계산합니다. 이보다는 그리디한 방법으로 무조건 피로도가 적게 드는 곡괭이를 우선 사용하여 피로도가 많이 드는 5개 묶음의 광물을 캐는 방법이 효율적일 것 같아 해당 방법을 고안하게 되었습니다.  
그리하여 구한 광물 5개 묶음 피로도를 피로도 순으로, 피로도가 덜 드는 곡괭이를 사용하여 캐기 위해 정렬의 개념을 떠올렸습니다. 이와 동시에 광물 하나하나에 대해 곡괭이로 캐는 피로도 계산을 위해 광물의 인덱스도 필요했습니다. 캐기 위해 필요한 피로도와 해당 묶음의 인덱스(= 5개 묶음의 시작 인덱스/5)가 동시에 필요했으므로 객체를 사용해야겠다는 생각을 했고, int[] 배열을 사용하기로 했습니다. 0에는 광물 피로도를 1에는 해당 묶음의 인덱스를 저장해준 후 이를 피로도 기준 정렬해주면 되었고, 그를 위해 PriorityQueue를 떠올렸습니다.  
PriorityQueue에 Comparator<int[]>() 객체의 compare 함수 override를 통해 원하는 우선순위를 적용하고, 원하는 순서대로 pq에 피로도를 저장하였습니다. 그 후 pq가 빌 때까지 5개 묶음 광물을 피로도 순으로 뽑아주며 해당 광물 묶음에 대해 현재 곡괭이로 캘 때의 피로도를 totalSum 변수에 더하여 문제를 해결했습니다. 이때 한 개 묶음을 캘 때마다 곡괭이의 개수를 -1씩 해주며 곡괭이의 개수가 0개인 경우 다음 곡괭이를 사용하는 로직도 포함해주었습니다.

## 🧐 참고 사항
PriorityQueue를 사용하지 않는다면 Comparable을 implement 하는 객체를 하나 만들어 List에 담고 sort해주어도 될 것 같습니다. 하지만 Collections의 sort() 메서드의 최악 시간복잡도인 O(NlogN)보다 PriorityQueue의 삽입, 삭제 시 시간복잡도인 O(logN)이 조금 더 빠르므로 저는 PriorityQueue 사용이 적합한 로직인 경우 PriorityQueue를 사용하고 있습니다.  
그리고 이번 문제는 코드를 깔끔하게 짜기에는 조금 복잡하게 풀었네요ㅠㅠ

## 📄 Reference
