### PR TITLE
08/27 연속 펄스 부분 수열의 합

### DIFF
--- a/hyun/august/PGMS_161988_연속펄스부분수열의합.java
+++ b/hyun/august/PGMS_161988_연속펄스부분수열의합.java
@@ -1,0 +1,31 @@
+package dp;
+
+// dp(1부터 펄스 수열, -1부터 펄스수열) -> O(2 * sequence 길이) = O(2*10^5)
+
+import java.util.*;
+
+public class PGMS_161988_연속펄스부분수열의합 {
+    public long func(int[] sequence, int first){
+        int[] arr = sequence.clone();
+        for(int i=0; i<arr.length; i++){
+            arr[i] *= first;
+            first *= (-1);
+        }
+
+        long sum = arr[0];
+        long result = arr[0];
+        for(int i=1; i<arr.length; i++){
+            sum = Math.max(sum + arr[i], arr[i]);
+            result = Math.max(result, sum);
+            //System.out.print(sum + " ");
+        }
+
+        //System.out.println("==" + result);
+        return result;
+
+    }
+    public long solution(int[] sequence) {
+        long answer = Math.max(func(sequence,1), func(sequence,-1));
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#23


## 📝 문제 풀이 전략 및 실제 풀이 방법
처음엔 슬라이딩 윈도우, 투포인터가 얼핏 떠올랐습니다. 하지만, 수열의 길이가 고정되어 있지 않는 다는 점에서 슬라이딩 윈도우를 적용할 수 없었고, 투포인터로 최대합을 구하기 위해서는 배열이 오름차순으로 정렬되어야 하지 않나 라는 생각에 빠르게 다른 알고리즘을 떠올렸습니다. ( 하지만, 투포인터로 풀어도 된다는 것을 문제 다 풀고 나서 깨달았습니다. left, right 를 배열의 인덱스를 가르키는 포인터라고 할때  right 를 늘려주면서 최대합을 구하다가 만약 직전까지의 합 + 현재 값 보다 현재값만을 선택했을때가 더 이득이라면 left 를 현재값으로 가리키게 하면 됩니다 !)

### DP
반복문을 돌면서 현재 값을 선택할때, (직전까지의 합 + 현재값) vs (현재값) 이 두개의 값 중 큰 값을 선택하면서 연속 부분 수열 최댓값을 구했습니다. 이렇게 되면 연속된 수열임을 보장할 수 있습니다.
아이디어는 이렇게 생각했으나, 알고리즘 분류를 그리디라고 생각했습니다. 이유는 현재 값을 선택할때마다 최적의 값을 선택한다고 생각했기 때문입니다. 하지만, 그리디 보다는 DP 에 가깝다는 것을 ChatGPT 를 통해 알 수 있었습니다. 제가 떠올린 아이디어는 현재까지의 합이 다음 결정에 영향을 주기 때문에 DP(동적계획법)에 가깝다는 것을 알게 되었습니다.

또한,  (직전까지의 합 + 현재값) vs (현재값) 을 선택하는 부분에서 코드를 잘못 쳤었는데, 새로운 문제의 답을 떠올리게 되었습니다. 코드부분에 comment 남겨놓을테니 제 생각이 맞는지 같이 고민해봤으면 합니다 !


## 🧐 참고 사항
프로그래머스는 print 문 해도 정답이 인정됬어서 오늘도 print 문 지우지 않고 그대로 제출했더니, 테스트케이스 뒷부분에서 출력 초과라고 print 문 지우라고 경고장 날렸습니다 ㅎㅎ 

## 📄 Reference
.
