### PR TITLE
연속 펄스 부분 수열의 합

### DIFF
--- a/hoo/august/week5/PGMS_240827_연속펄스부분수열의합.java
+++ b/hoo/august/week5/PGMS_240827_연속펄스부분수열의합.java
@@ -1,0 +1,44 @@
+package august.week5;
+
+import java.util.Arrays;
+
+public class PGMS_240827_연속펄스부분수열의합 {
+
+    int[] multipliedInOrder;    // 1, -1, 1, ... 을 곱한 값
+    int[] multipliedReverseOrder;   // -1, 1, -1, ... 을 곱한 값
+    long maxValue;   // 최댓값 저장할 변수
+
+    public long solution(int[] sequence) {
+        init(sequence);
+        long answer = findMaxValue();
+
+        return answer;
+    }
+
+    void init(int[] sequence) {
+        multipliedInOrder = new int[sequence.length];
+        multipliedReverseOrder = new int[sequence.length];
+        int[] pulse = new int[] {1, -1};    // 펄스 수열을 곱해주기 위한 배열
+        for (int i = 0; i < sequence.length; i++) { // sequnce에 1부터 시작하는 펄스 수열, -1부터 시작하는 펄스 수열을 각각 곱해줌
+            multipliedInOrder[i] = sequence[i] * pulse[i%2];
+            multipliedReverseOrder[i] = sequence[i] * pulse[(i+1)%2];
+        }
+        maxValue = Long.MIN_VALUE;
+    }
+
+    long findMaxValue() {   // 펄스 수열을 곱한 배열에 대해 원소들의 합이 최댓값인 부분 수열 찾는 함수
+        int l = multipliedInOrder.length;
+        long[][] dpArr = new long[2][l];  // 0: 1부터 시작한 펄스 수열 곱한 배열의 연속 부분 수열 합 최댓값 저장, 1: -1부터 시작한 펄스 수열에 대해서 동일한 동작 수행
+        dpArr[0][0] = multipliedInOrder[0];
+        dpArr[1][0] = multipliedReverseOrder[0];
+        for (int i = 1; i < l; i++) {
+            dpArr[0][i] = Math.max(0, dpArr[0][i-1]) + multipliedInOrder[i];
+            dpArr[1][i] = Math.max(0, dpArr[1][i-1]) + multipliedReverseOrder[i];
+        }
+        Arrays.sort(dpArr[0]);
+        Arrays.sort(dpArr[1]);
+
+        return Math.max(dpArr[0][l-1], dpArr[1][l-1]);
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #23 

## 📝 문제 풀이 전략 및 실제 풀이 방법
문제를 보고 처음에는 그리디하게 풀어야 하는가? 라는 생각이 들었습니다. 몇 개를 뽑아서 그 부분에 대해 펄스 수열을 곱해주어야 하는데, 어떻게 뽑는가에 대해 고민을 했다라는 말씀입니다.
하지만 순서를 바꿔서 생각해보니 1부터 시작하는 펄스 수열과 -1부터 시작하는 펄스 수열 각각을 sequence에 곱해준 값을 가지고 있다면, 그 값에서 최대 합을 가지는 부분 수열의 합만 찾으면 된다는 생각이 들었고 그렇게 해결했습니다.
문제 풀이를 위해 위에서 말한 두가지 경우의 값을 저장한 배열에 대해 동적 프로그래밍을 수행해주었습니다. 연속 부분 수열의 합에 대한 점화식은 "dpArr[i] = originArr[i], i == 0 / Math.max(0, dpArr[i-1]) + originArr[i], i != 0"와 같이 세울 수 있습니다. 이렇게 동적 프로그래밍을 수행, 두 배열의 최댓값 중 최댓값을 반환해주면 정답이 됩니다.

## 🧐 참고 사항

## 📄 Reference
