### PR TITLE
08/28 네트워크

### DIFF
--- a/hyun/august/PGMS_43162_네트워크.java
+++ b/hyun/august/PGMS_43162_네트워크.java
@@ -1,0 +1,26 @@
+package dfs;
+
+public class PGMS_43162_네트워크 {
+
+    public void dfs(int num, boolean[] visited, int n, int[][] computers){
+        visited[num] = true;
+
+        for(int i=0; i<n; i++){
+            if(num == i || visited[i] || computers[num][i] == 0) continue;
+            dfs(i,visited,n,computers);
+        }
+    }
+
+    public int solution(int n, int[][] computers) {
+        int answer = 0;
+        boolean[] visited = new boolean[n];
+
+        for(int i=0; i<n; i++){
+            if(visited[i]) continue;
+            dfs(i,visited,n,computers);
+            answer++;
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#26 


## 📝 문제 풀이 전략 및 실제 풀이 방법
서로 연결된 그룹들의 갯수를 찾는 문제로 DFS,BFS를 떠올렸습니다.
평소에 BFS 로 구현을 많이 했어서 이번엔 DFS로 접근했습니다.

구현은 아주 기초적인 DFS 로
- 1번 노드부터 시작해 방문하지 않았다면 서로 연결되어 있는 노드들을 모두 방문해줍니다.
- 이렇게 하나의 그룹을 찾을 수 있으며, 각 노드들의 방문 상태를 확인하여 그룹핑을 해주면 됩니다.

## 🧐 참고 사항
.

## 📄 Reference
.
