### PR TITLE
PGMS_240829_인사고과, PGMS_240830_등굣길

### DIFF
--- a/hoo/august/week5/PGMS_240829_인사고과.java
+++ b/hoo/august/week5/PGMS_240829_인사고과.java
@@ -1,0 +1,56 @@
+package august.week5;
+
+import java.util.PriorityQueue;
+
+public class PGMS_240829_인사고과 {
+
+    class Employee implements Comparable<Employee> {
+        int aScore; // 근무 태도 점수
+        int bScore; // 동료 평가 점수
+        int index;  // 주어진 사원의 인덱스
+
+        public Employee(int aScore, int bScore, int index) {
+            this.aScore = aScore;
+            this.bScore = bScore;
+            this.index = index;
+        }
+
+        @Override
+        public String toString() { return this.aScore + " " + this.bScore + " " + this.index; }
+
+        @Override
+        public int compareTo(Employee e) {
+            if (this.aScore == e.aScore) {
+                return this.bScore - e.bScore; // aScore 동점 시 bScore(동료 평가 점수) 오름차순 정렬
+            }
+            return e.aScore - this.aScore;  // aScore(근무 태도 점수) 기준 내림차순 정렬
+        }
+    }
+
+    public int solution(int[][] scores) {
+        int answer = calcGrade(scores);
+
+        return answer;
+    }
+
+    int calcGrade(int[][] scores) {
+        PriorityQueue<Employee> pq = new PriorityQueue<>();
+        for (int i = 0; i < scores.length; i++) pq.offer(new Employee(scores[i][0], scores[i][1], i));
+
+        int grade = 1;  // 1등부터 등수 세알리기
+        boolean canReceiveIncentive = false;    // 원호가 인센티브를 받았는 지 여부 저장
+        int maxBscore = 0;  // 현재 aScore를 기준으로 내림차순 정렬임. 이때 사원의 bScore가 이전까지 최대 bScore보다 낮다면 인센티브를 못 받는 것임.
+        Employee now;
+        while (!pq.isEmpty()) {
+            now = pq.poll();
+            if (now.bScore < maxBscore) continue;   // 인센티브를 받지 못하는 사원은 인센티브 로직에서 생각을 안하게끔 건너 뜀
+            if (now.index == 0) canReceiveIncentive = true;   // 원호가 인센티브를 받은 경우, 받았다고 체크
+
+            maxBscore = Math.max(maxBscore, now.bScore);    // 최대 bScore 갱신
+            if (now.aScore + now.bScore > scores[0][0] + scores[0][1]) grade++;   // 원호보다 합산 점수 높은 애들에 대해서 등수를 매겨 줌
+        }
+
+        return (canReceiveIncentive)? grade:-1; // 모든 직원에 대해 검사를 했지만 원호가 인센티브를 받지 못한 경우는 -1 반환, 아니라면 원호의 등수 반환
+    }
+
+}

--- a/hoo/august/week5/PGMS_240829_인사고과_실패코드.java
+++ b/hoo/august/week5/PGMS_240829_인사고과_실패코드.java
@@ -1,0 +1,63 @@
+package august.week5;
+
+import java.util.PriorityQueue;
+
+public class PGMS_240829_인사고과_실패코드 {
+
+    class Employee implements Comparable<Employee> {
+        int aScore; // 근무 태도 점수
+        int bScore; // 동료 평가 점수
+        int index;  // 주어진 사원의 인덱스
+
+        public Employee(int aScore, int bScore, int index) {
+            this.aScore = aScore;
+            this.bScore = bScore;
+            this.index = index;
+        }
+
+        @Override
+        public String toString() { return this.aScore + " " + this.bScore + " " + this.index; }
+
+        @Override
+        public int compareTo(Employee e) {
+            if ((e.aScore + e.bScore) == (this.aScore + this.bScore)) return this.index - e.index;
+            return (e.aScore + e.bScore) - (this.aScore + this.bScore); // 내림차순 정렬
+        }
+    }
+
+    public int solution(int[][] scores) {
+        int answer = calcGrade(scores);
+
+        return answer;
+    }
+
+    int calcGrade(int[][] scores) {
+        PriorityQueue<Employee> pq = new PriorityQueue<>();
+        for (int i = 0; i < scores.length; i++) {
+            pq.offer(new Employee(scores[i][0], scores[i][1], i));
+        }
+
+        int grade = 0;  // 등수 세알리기
+        boolean canReceiveIncentive = false;    // 원호가 인센티브를 받았는 지 여부 저장
+        int[] maxScore = new int[2]; // a점수와 b점수의 최댓값을 이용, 인센티브를 받지 못하는 경우 걸러낸다
+        Employee now;
+
+        while (!pq.isEmpty()) {
+            now = pq.poll();
+
+            if (now.aScore > maxScore[0] || now.bScore > maxScore[1]) {   // 현재 고용자의 점수 중 하나라도 저장된 최대 점수보다 높다면
+                if (now.aScore > maxScore[0] && now.bScore > maxScore[1]) maxScore = new int[] {now.aScore, now.bScore};   // 모든 점수가 다 높으면 무조건 갱신
+                else if (Math.abs(now.aScore - now.bScore) < Math.abs(maxScore[0] - maxScore[1])) maxScore = new int[] {now.aScore, now.bScore};    // 그게 아니라면 고과 비교하기 좋게 점수 차가 작은 값으로 갱신
+            } else if (now.aScore < maxScore[0] && now.bScore < maxScore[1]) continue;
+
+            grade++;
+            if (now.index == 0) {   // 원호가 인센티브를 받은 경우임
+                canReceiveIncentive = true;
+                break;
+            }
+        }
+
+        return (canReceiveIncentive)? grade:-1;
+    }
+
+}

--- a/hoo/august/week5/PGMS_240830_등굣길.java
+++ b/hoo/august/week5/PGMS_240830_등굣길.java
@@ -1,0 +1,57 @@
+package august.week5;
+
+public class PGMS_240830_등굣길 {
+
+    public int solution(int m, int n, int[][] puddles) {
+        int answer = calcRoutes(m, n, puddles);
+
+        return answer;
+    }
+
+    int calcRoutes(int m, int n, int[][] puddles) {
+        int MAX_DIST = 10_001;
+        int[][][] routeDist = new int[n+1][m+1][2]; // 3차원의 0번 인덱스에는 최소 거리 저장, 1번 인덱스에는 횟수 저
+
+        for (int i = 1; i <= n; i++) {   // 우선 각 칸까지 걸리는 거리 최대 거리로 초기화
+            for (int j = 1; j <= m; j++) routeDist[i][j][0] = MAX_DIST;
+        }
+        for (int i = 0; i < puddles.length; i++) routeDist[puddles[i][1]][puddles[i][0]][0] = -1;   // 물 웅덩이는 -1로 표시
+        if (routeDist[1][2][0] == -1 && routeDist[2][1][0] == -1) return 0; // 집 주변이 다 웅덩이인 경우 학교를 못 감
+
+        routeDist[1][1][0] = 0; // 출발지 거리는 0
+        routeDist[1][1][1] = 1; // 출발지의 경우는 1
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= m; j++) {
+                if (routeDist[i][j][0] != MAX_DIST || routeDist[i][j][0] == -1) continue;   // 이미 거리를 파악한 칸, 물 웅덩이 칸은 건너 뜀
+                int nowDist = MAX_DIST;
+                int nowRouteCount = 0;  // 현재 칸에 왼쪽, 윗쪽에서 올 수 있는 경우의 수
+                int leftDist = MAX_DIST, upperDist = MAX_DIST;    // 왼쪽칸까지 오는 데 걸린 거리, 윗쪽칸까지 오는 데 걸린 거리
+                if (!isOutedOrPuddle(m, n, routeDist, i, j-1)) leftDist = routeDist[i][j-1][0];
+                if (!isOutedOrPuddle(m, n, routeDist, i-1, j)) upperDist = routeDist[i-1][j][0];
+
+                if (leftDist == upperDist && leftDist != MAX_DIST) {   // 두 방향 모두에서 올 수 있는 경우, 근데 두 방향 모두 최대거리인 경우는 도달하지 못하는 경우임
+                    nowDist = routeDist[i][j-1][0] + 1;
+                    nowRouteCount = (routeDist[i][j-1][1] + routeDist[i-1][j][1]) % 1_000_000_007;
+                }
+                else if (leftDist < upperDist) {    // 왼쪽에서 오는 게 더 빠른 경우
+                    nowDist = routeDist[i][j-1][0] + 1;
+                    nowRouteCount = routeDist[i][j-1][1];
+                } else if (leftDist > upperDist) {
+                    nowDist = routeDist[i-1][j][0] + 1;
+                    nowRouteCount = routeDist[i-1][j][1];
+                }
+
+                routeDist[i][j][0] = nowDist;
+                routeDist[i][j][1] = nowRouteCount;
+            }
+        }
+
+        return routeDist[n][m][1];
+    }
+
+    boolean isOutedOrPuddle(int m, int n, int[][][] routeDist, int row, int col) {
+        if ((1 <= row && row <= n) && (1 <= col && col <= m) && routeDist[row][col][0] != -1) return false;
+        return true;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #29 
+ #32 

## 📝 문제 풀이 전략 및 실제 풀이 방법
1. 인사고과
+ 처음 시도한 풀이
 우선 문제를 보고 바로 떠오른 것은 정렬에 대한 것이었습니다. 저는 정렬에 관한 문제 해결 시 우선순위 큐를 사용하는 것을 선호하는 편이어서 우선순위 큐를 사용하기로 결정, 여기에 쓰일 객체를 comparable을 상속하도록 하였습니다.
 이후 이 객체의 compareTo 함수에 정렬 조건을 정해주었습니다. 처음에 든 생각이 
  1. 합을 기준으로 내림차순 정렬
  2. 그 안에서 인덱스를 기준으로 오름차순 정렬  
 
  이었고, 인센티브를 받지 못하는 사람에 대한 처리를 해주기 위해 aScore(근무 태도 점수)와 bScore(동료 평가 점수)를 가장 인센티브를 못 받는 사람을 잘 거를 수 있는 값으로 유지하고자 했습니다. 이를 위해 aScore나 bScore 중 아무 값이나 현재 저장된 값보다 높다면, 이 값의 차이를 비교하여 최소 차이를 가지는 값으로 갱신하도록 해주었습니다.
 하지만 이에서 (2, 6), (4, 4), (1, 5)와 같은 예외 상황이 발생하는 것을 간과하였습니다. 문제의 조건 대로라면 (1, 5)의 평가를 받은 사원은 (2, 6)과의 비교를 통해 인센티브를 못받아야 하지만, 제가 처리한 대로라면 (4, 4)와 비교가 되어 인센티브를 받을 수 있게 됩니다. 이 예외를 통해 합을 기준으로 정렬하는 것은 인센티브 수령 여부에 대한 처리가 애매함을 인지, 다른 정렬 방법을 떠올리게 되었습니다.

+ 이후의 풀이
 다른 정렬 방법으로 떠오른 것은 인센티브 수령 여부 확인을 위함이 큽니다. 우선 aScore를 기준으로 내림차순 정렬해주면 앞전까지의 bScore 중 최대 값보다 현재 bScore가 낮은 지만 판단하면 인센티브 수령 여부를 판단할 수 있습니다. 하지만 이때 조심해야 할 점은, 같은 aScore 안에서 bScore를 오름차순으로 정렬해주어야 한다는 것입니다. 그렇지 않으면 (2, 1), (3, 1), (2, 2)과 같은 문제에서 원호가 원래는 인센티브를 받을 수 있지만, (3, 1), (2, 2), (2, 1)과 같이 정렬되면 인센티브를 받지 못한다고 판단할 수 있기 때문입니다.그리하여 정렬 기준을
  1. aScore 기준 내림차순 정렬
  2. aScore가 같은 경우는 bScore를 기준으로 오름차순 정렬

  로 수정해주었습니다. 이후 이 기준을 따라 우선순위 큐에 저장된 원소들을 poll해주며 인센티브를 받을 수 있으며 원호보다 높은 합을 가진 사원의 수를 카운트하여 원호의 등수를 매겨주었습니다. 이때 원호가 인센티브를 받았는 지 여부를 체크, 받지 않았다면 -1을 받았다면 등수를 반환하게끔 하여 문제를 해결하였습니다.


2. 등굣길
문제 조건에 dp가 명시 되어 있긴 했지만, 처음에는 bfs를 이용한 풀이를 시도했습니다. 최소 거리를 저장하는 배열을 메모이제이션 방식으로 이용, 최소 거리가 아닌 루트는 잘라내는 방식으로 풀이를 진행했으나 효율성 테스트에서 모두 시간 초과가 발생했습니다. 그 후에 시간 복잡도를 한 번 계산해보니 2^(n*m)이 나오더라구요. 택도 없는 방법이었던 걸 알고는 최적화 하기 보다는 바로 dp로 선회했습니다.
dp로는 삼차원 배열을 이용, 현재 칸에서 지나온 길을 돌아보는 방식으로 해결했습니다. 우선 현재의 칸이 이미 계산했던 칸이거나(집 위치에서 계산하는 것 방지) 물 웅덩이라면 거리를 계산하지 않습니다. 이런 조건 밖의 경우는 왼쪽과 윗쪽에서의 거리를 파악, 최소 거리인 곳에서의 오는 방법 수를 현재 칸에도 저장해줍니다. 이때 두 방향 모두가 같은 거리로 도달할 수 있다면 두 방향에서의 방법을 합친 값을 현재 칸의 방법으로 저장합니다. 이런 방식으로 학교까지 수행, 답을 출력해주었습니다.

## 🧐 참고 사항
어제 PR을 오늘 수정하느라 merge가 안된 상태인 걸 까먹고 push를 해버려서 PR이 합쳐졌습니다. 참고하시길 바랍니다.

## 📄 Reference
