### PR TITLE
Hoo

### DIFF
--- a/hoo/september/week1/PGMS_240908_업그레이드된아이템구하기.sql
+++ b/hoo/september/week1/PGMS_240908_업그레이드된아이템구하기.sql
@@ -1,6 +1,6 @@
 select a.item_id, b.item_name, b.rarity
 from item_tree a
-left join item_info b
+join item_info b
 on a.item_id = b.item_id
 where a.parent_item_id in
 (select item_id

--- a/hoo/september/week1/PGMS_240908_업그레이드된아이템구하기.sql
+++ b/hoo/september/week1/PGMS_240908_업그레이드된아이템구하기.sql
@@ -1,0 +1,9 @@
+select a.item_id, b.item_name, b.rarity
+from item_tree a
+left join item_info b
+on a.item_id = b.item_id
+where a.parent_item_id in
+(select item_id
+from item_info
+where rarity = "RARE")
+order by a.item_id desc;


### PR DESCRIPTION
## 🔍 개요
+ #50 

## 📝 문제 풀이 전략 및 실제 풀이 방법
하금티 코테 준비 때 sql을 좀 열심히 준비했는데, 그때 제가 문제에 접근했던 공부법에 대해 공유드릴까 합니다. 테이블 두 개 이상을 주는 문제가 나올 확률이 높아 join, group by를 잘 사용해야 합니다. 그 중에서도 오늘은 join을 활용하는 문제였으므로 join에 대해 알아보겠습니다.  
이 문제에서는
1. rarity가 "RARE"인 모든 아이템에 대해
2. 다음 업그레이드 아이템을 구하고
3. 그들의 item_id, item_name, rarity를 출력하세요
4. item_id에 대해 내림차순으로

를 요구하고 있습니다. 이때 1번은 ITEM_INFO에서, 2번은 ITEM_TREE에서 parent_item_id를 통해 구할 수 있습니다. 저는 최종적으로 구해야 하는 "다음 업그레이드 아이템"을 먼저 select로 구해오는 편입니다. 그럼 우선의 sql문은 "select * from item_tree;" 가 되겠죠?  

그런데 "다음 업그레이드 아이템인데 무엇의?"가 필요합니다. 여기서 무엇의?는 문제에서 줬던 "rarity가 RARE인"입니다. rarity는 item_info 테이블에서 얻을 수 있습니다. 그 조건을 위의 select 문에 넣어줍니다. 그럼 
"select * from item_tree 
where parent_id in (select item_id from item_info where rarity = "RARE")" => 이 부분이 "무엇의?"에 해당함
과 같이 구성이 될 것입니다. 여기까지 해주면 item_tree 테이블에서 조건에 맞는 row들을 뽑아올 수 있습니다.  

이후에는 문제의 최종 출력 조건에 부합하게 select 문을 수정해주어야 합니다. 이때 item_id는 item_tree에 있지만 item_name, rarity은 item_info 테이블을 이용해야 합니다. 이때 join문이 사용되게 됩니다.(join도 엄밀히 따지자면 inner join이 되겠지만, mysql에서는 join이라는 키워드가 기본적으로 inner join을 사용하기에 join만 사용해도 됩니다.) 위의 select 문에서 item_tree를 약어 a로, item_info를 약어 b로 통칭하고 join문을 추가하면 
"select * from item_tree a 
join item_info b 
on a.item_id=b.item_id 
where a.parent_id in (select item_id from item_info where rarity = "RARE")"
와 같이 앞선 select 문에서 조건에 해당하는 row를 뽑아온 것에 원하는 값을 뽑아올 join문만 추가함으로써 문제 해결에 필요한 row들을 가져올 수 있습니다. 이후에는 적절하게 *로 모든 속성을 다 뽑아왔던 것을 item_id, item_name, rarity를 a, b 각 테이블에서 뽑아 출력하는 것으로 수정해주면 됩니다. 최종 정렬 조건인 내림차순은 단순히 order by item_id desc를 추가해주면 됩니다.

## 🧐 참고 사항
관련한 썰 하나가 있는데, 하금티 코테 때 join 할 테이블의 약어 지정을 계속 select * from a as a 처럼 as를 붙여서 하는데 오류가 발생하더라구요. 알고 보니 코테에서 사용하는 문법이 MySQL 문법이 아니었던 거죠.. 그래서 되게 얼타고 시간 날렸던 경험이 있습니다. 
Oracle 문법이 어떤 지는 몰라도 이런 부분에서 헷갈리고 갈 요소는 줄이기 위해서 그 뒤로는 약어 지정해줄 때 as를 안 붙이고 있습니다.

## 📄 Reference
