### PR TITLE
09/09 : 최고의 집합

### DIFF
--- a/hyun/september/PGMS_12938_최고의집합.java
+++ b/hyun/september/PGMS_12938_최고의집합.java
@@ -1,0 +1,24 @@
+package implementation;
+
+import java.util.*;
+
+public class PGMS_12938_최고의집합 {
+    public int[] solution(int n, int s) {
+        int[] answer;
+
+        if(n==s) return new int[]{s};
+        else if(n > s) return new int[]{-1};
+        else{
+            int m = s / n;
+            int r = s % n;
+            answer = new int[n];
+            for(int i=0; i<n; i++){
+                if(i < r ) answer[i] = m + 1;
+                else answer[i] = m;
+            }
+        }
+
+        Arrays.sort(answer);
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#53 


## 📝 문제 풀이 전략 및 실제 풀이 방법
곱이 최대가 되기 위해서는 집합안의 원소들이 차이가 없이 골고루 분배되어야 한다고 생각했습니다. 따라서, 합 S 를 갯수 n 개로 나누어 준 몫을 먼저 정답 배열에 배치한 다음 나머지가 있으면 1씩 나누어 주도록 구성했습니다 !

## 🧐 참고 사항
.

## 📄 Reference
.
