### PR TITLE
PGMS_240912_시소짝꿍

### DIFF
--- a/hoo/september/week2/PGMS_240912_시소짝꿍.java
+++ b/hoo/september/week2/PGMS_240912_시소짝꿍.java
@@ -1,4 +1,61 @@
 package september.week2;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class PGMS_240912_시소짝꿍 {
+
+    public long solution(int[] weights) {
+        Map<Integer, Integer> sameNumberMap = findSameNumbers(weights);  // 우선 같은 수가 몇 번 나오는 지 숫자마다 모두 체크
+        long answer = countPair(weights, sameNumberMap);  // 그 후 짝지을 수 있는 경우를 게산
+
+        return answer;
+    }
+
+    Map<Integer, Integer> findSameNumbers(int[] weights) {  // 숫자들의 등장 횟수를 파악
+        Map<Integer, Integer> sameNumberMap = new HashMap<>();
+        for (int i = 0; i < weights.length; i++) {
+            if (sameNumberMap.containsKey(weights[i])) sameNumberMap.put(weights[i], sameNumberMap.get(weights[i])+1);
+            else sameNumberMap.put(weights[i], 1);
+        }
+
+        return sameNumberMap;
+    }
+
+    long countPair(int[] weights, Map<Integer, Integer> sameNumberMap) {
+        long answer = 0;
+        List<Integer> noDuplicateNumbers = makeNoDuplicateNumbers(weights, sameNumberMap);  // 같은 숫자 중복을 제거한 숫자들만 남긴 리스트 생성
+        int[] multipliedWeights = new int[4_001];   // 각 무게에 2, 3, 4를 곱한 값을 저장할 배열
+        for (int i = 0; i < noDuplicateNumbers.size(); i++) {
+            for (int j = 2; j <= 4; j++) {
+                multipliedWeights[noDuplicateNumbers.get(i) * j] += sameNumberMap.get(noDuplicateNumbers.get(i));
+            }
+            if (sameNumberMap.get(noDuplicateNumbers.get(i)) >= 2) answer -= calcCombination(sameNumberMap.get(noDuplicateNumbers.get(i))) * 2L; // 중복되는 수가 있는 경우는 만들 수 있는 조합 개수 * 2(결국 2, 3, 4 곱한 세 가지 중 한 경우만 카운트 돼야하므로)를 미리 빼줌
+        }
+
+        for (int i = 0; i < multipliedWeights.length; i++) {    // 각 무게를 만들 수 있는 경우가 2 이상이면 짝이루는 게 가능함. 그 개수에서 2개를 고르는 조합의 수를 정답에 더해줌
+            if (multipliedWeights[i] >= 2) answer += calcCombination(multipliedWeights[i]);
+        }
+
+        return answer;
+    }
+
+    long calcCombination(int n) {  // n개 중 2개를 골라 쌍을 만드는 경우를 계산
+        return (long) n * ((long) n - 1L) / 2L;
+    }
+
+    List<Integer> makeNoDuplicateNumbers(int[] weights, Map<Integer, Integer> sameNumberMap) {  // 중복이 없는 수로 이루어진 리스트를 생성하는 함수
+        boolean[] isChecked = new boolean[1_001];
+        List<Integer> noDuplicateNumbers = new ArrayList<>();
+        for (int i = 0; i < weights.length; i++) {
+            if (isChecked[weights[i]]) continue;   // 이미 앞에서 계산한 여러개인 수이므로 건너 뜀
+            else if (sameNumberMap.get(weights[i]) > 1) isChecked[weights[i]] = true;
+            noDuplicateNumbers.add(weights[i]);
+        }
+
+        return noDuplicateNumbers;
+    }
+
 }

--- a/hoo/september/week2/PGMS_240912_시소짝꿍.java
+++ b/hoo/september/week2/PGMS_240912_시소짝꿍.java
@@ -1,0 +1,4 @@
+package september.week2;
+
+public class PGMS_240912_시소짝꿍 {
+}

--- a/hoo/september/week2/PGMS_240912_시소짝꿍_정리안한거.java
+++ b/hoo/september/week2/PGMS_240912_시소짝꿍_정리안한거.java
@@ -1,0 +1,69 @@
+package september.week2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PGMS_240912_시소짝꿍_정리안한거 {
+
+    public long solution(int[] weights) {
+        Map<Integer, Integer> sameNumberMap = findSameNumbers(weights);
+        long answer = countFair(weights, sameNumberMap);
+
+        return answer;
+    }
+
+    Map<Integer, Integer> findSameNumbers(int[] weights) {  // 숫자들의 등장 횟수를 파악
+        Map<Integer, Integer> sameNumberMap = new HashMap<>();
+        for (int i = 0; i < weights.length; i++) {
+            if (sameNumberMap.containsKey(weights[i])) sameNumberMap.put(weights[i], sameNumberMap.get(weights[i])+1);
+            else sameNumberMap.put(weights[i], 1);
+        }
+        // System.out.println(sameNumberMap);
+
+        return sameNumberMap;
+    }
+
+    long countFair(int[] weights, Map<Integer, Integer> sameNumberMap) {
+        long answer = 0;
+        List<Integer> noDuplicateNumbers = makeNoDuplicateNumbers(weights, sameNumberMap);  // 같은 숫자로 이루어진 쌍은 미리 정답에 계산 후 중복을 제거한 숫자들만 남긴 리스트 생성
+        // System.out.println(answer);
+        // System.out.println(noDuplicateNumbers);
+        // 2100 => 1050, 700, 525으로 만들기 가능
+        // -> 체크하면 숫자 3 저장돼있을 거임
+        // 525, 525, 700, 1050
+        int[] multipliedWeights = new int[4_001];   // 각 무게에 2, 3, 4를 곱한 값을 저장할 배열
+        for (int i = 0; i < noDuplicateNumbers.size(); i++) {
+            for (int j = 2; j <= 4; j++) {
+                multipliedWeights[noDuplicateNumbers.get(i) * j] += sameNumberMap.get(noDuplicateNumbers.get(i));
+            }
+            if (sameNumberMap.get(noDuplicateNumbers.get(i)) >= 2) answer -= calcCombination(sameNumberMap.get(noDuplicateNumbers.get(i))) * 2L; // 같은 수는 만들 수 있는 조합 개수 * 2(결국 2, 3, 4 곱한 것 중 한 조합만 카운트 돼야하므로)를 미리 빼줌
+        }
+
+        for (int i = 0; i < multipliedWeights.length; i++) {
+            if (multipliedWeights[i] >= 2) answer += calcCombination(multipliedWeights[i]);
+        }
+
+        // System.out.println(answer);
+
+        return answer;
+    }
+
+    long calcCombination(int n) {  // n개 중 2개를 골라 쌍을 만드는 경우를 계산
+        return (long) n * ((long) n - 1L) / 2L;
+    }
+
+    List<Integer> makeNoDuplicateNumbers(int[] weights, Map<Integer, Integer> sameNumberMap) {
+        boolean[] isChecked = new boolean[1_001];
+        List<Integer> noDuplicateNumbers = new ArrayList<>();
+        for (int i = 0; i < weights.length; i++) {
+            if (isChecked[weights[i]]) continue;   // 이미 앞에서 계산한 여러개인 수이므로 건너 뜀
+            else if (sameNumberMap.get(weights[i]) > 1) isChecked[weights[i]] = true;
+            noDuplicateNumbers.add(weights[i]);
+        }
+
+        return noDuplicateNumbers;
+    }
+
+}

--- a/hoo/september/week2/PGMS_240912_시소짝꿍_정리안한거.java
+++ b/hoo/september/week2/PGMS_240912_시소짝꿍_정리안한거.java
@@ -27,7 +27,7 @@ public class PGMS_240912_시소짝꿍_정리안한거 {
 
     long countFair(int[] weights, Map<Integer, Integer> sameNumberMap) {
         long answer = 0;
-        List<Integer> noDuplicateNumbers = makeNoDuplicateNumbers(weights, sameNumberMap);  // 같은 숫자로 이루어진 쌍은 미리 정답에 계산 후 중복을 제거한 숫자들만 남긴 리스트 생성
+        List<Integer> noDuplicateNumbers = makeNoDuplicateNumbers(weights, sameNumberMap);  // 같은 숫자 중복을 제거한 숫자들만 남긴 리스트 생성
         // System.out.println(answer);
         // System.out.println(noDuplicateNumbers);
         // 2100 => 1050, 700, 525으로 만들기 가능
@@ -38,7 +38,7 @@ public class PGMS_240912_시소짝꿍_정리안한거 {
             for (int j = 2; j <= 4; j++) {
                 multipliedWeights[noDuplicateNumbers.get(i) * j] += sameNumberMap.get(noDuplicateNumbers.get(i));
             }
-            if (sameNumberMap.get(noDuplicateNumbers.get(i)) >= 2) answer -= calcCombination(sameNumberMap.get(noDuplicateNumbers.get(i))) * 2L; // 같은 수는 만들 수 있는 조합 개수 * 2(결국 2, 3, 4 곱한 것 중 한 조합만 카운트 돼야하므로)를 미리 빼줌
+            if (sameNumberMap.get(noDuplicateNumbers.get(i)) >= 2) answer -= calcCombination(sameNumberMap.get(noDuplicateNumbers.get(i))) * 2L; // 중복되는 수가 있는 경우는 만들 수 있는 조합 개수 * 2(결국 2, 3, 4 곱한 세 가지 중 한 경우만 카운트 돼야하므로)를 미리 빼줌
         }
 
         for (int i = 0; i < multipliedWeights.length; i++) {

--- a/hoo/september/week2/PGMS_240913_124나라의숫자.java
+++ b/hoo/september/week2/PGMS_240913_124나라의숫자.java
@@ -1,0 +1,24 @@
+package september.week2;
+
+public class PGMS_240913_124나라의숫자 {
+
+    public String solution(int n) {
+        StringBuilder answer = new StringBuilder();
+
+        while (n > 0) {
+            int num = n%3;
+            if (num == 0) {
+                answer.insert(0, "4");
+                n = n/3 - 1;
+            }
+            else {
+                answer.insert(0, Integer.toString(num));
+                n = n/3;
+            }
+
+        }
+
+        return answer.toString();
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #62 

## 📝 문제 풀이 전략 및 실제 풀이 방법
주어진 weights의 길이가 10만인 걸 보고 우선 O(N) 혹은 O(logN)이나 O(NlogN)만에 해내야하는 문제라고 생각했습니다. 그렇게 든 생각이 우선은 투포인터였습니다. 하지만 이 경우 100과 300의 비교 후 180과 300은 비교가 불가능 하게 되는 문제가 있어 포기했습니다.
그 후 각 weight 별 2, 3, 4를 곱한 값을 int[] 배열에 카운트해주면 어떨까?라는 생각을 하게 되었습니다. 하지만 이때 예제의 100과 같이 중복으로 등장하는 수가 있어 이에 대한 처리가 필요했습니다. 그리하여
1. weights를 순회하며 중복되는 수들의 개수를 세알려 Map에 저장해주고
2. 중복을 없애고 weight들을 저장한 리스트를 만들어준다
3. 그 리스트를 순회하며 2, 3, 4를 곱한 값 인덱스에 카운트하고 저장할 배열(이하 카운트 배열)을 생성하고
4. 그 리스트를 순회하며 2, 3, 4를 곱한 값을 카운트 배열 인덱스에 이 숫자의 개수를 Map에서 가져와서 카운트해준다
5. 카운트 배열을 순회하며 2 이상의 값을 가지는 경우, 그 개수 중 2개를 뽑을 수 있는 경우의 수인 nC2 의 값을 정답에 더해준다

의 방식으로 풀이했습니다. 여기서 중복되는 수들을 빼주는 작업이 필요한데요, 5번까지의 과정을 마친 후 한 번 더 반복문을 돌며 수행해도 되지만 저는 위의 단계 중 4번 단계에서 미리 이 작업이 수행되게 하였습니다. 
중복을 없앤 weight들이 저장된 리스트를 순회하며, Map에서 그를 key로 가지는 값들 중 2개 이상인 녀석들은 중복이 되는 녀석들입니다. 저는 4번 과정을 수행하며 정답에서 미리 Map의 value 중 2개를 뽑는 경우의 수인 nC2에 2를 곱한 값을 빼주었습니다. 2, 3, 4를 곱한 값 중 실제로는 2를 곱한 값만 카운트 돼야하는데 3, 4를 곱한 값도 중복으로 카운트 됐으니 nC2 * 2를 빼준 것입니다.

그럼으로써 weights에 대한 전체 순회가 최악의 경우 3번 수행되는 로직으로 O(N)의 시간복잡도로 해결할 수 있었습니다. 사실 여기서 Map을 만드는 과정과 중복을 없앤 List를 만드는 과정은 한 번의 순회로 해결하도록 수정이 가능하나, 문제를 풀이했던 그때의 정신머리로는 그러지 못했습니다.

## 🧐 참고 사항

## 📄 Reference
