### PR TITLE
PGMS_240918_기지국설치

### DIFF
--- a/hoo/september/week3/PGMS_240918_기지국설치.java
+++ b/hoo/september/week3/PGMS_240918_기지국설치.java
@@ -1,0 +1,69 @@
+package september.week3;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class PGMS_240918_기지국설치 {
+
+    public int solution(int n, int[] stations, int w) {
+        int answer = construct5G(n, stations, w);
+
+        return answer;
+    }
+
+    int construct5G(int n, int[] stations, int w) {
+        int constructCount = 0;
+
+        int markCount = 0;
+        boolean[] mark = makeMark(n, stations, w);
+        for (int i = 1; i <= n; i++) if (mark[i]) markCount++;
+        Queue<Integer> q = makeInitStationsQueue(n, stations, w);
+
+        int nowStation;
+        int stationLeft, stationRight;
+        while (!q.isEmpty() && markCount < n) {
+            nowStation = q.poll();
+            stationLeft = nowStation - (2*w+1);
+            stationRight = nowStation + (2*w+1);
+            constructCount++;
+            for (int i = Math.max(1, nowStation - w); i <= Math.min(n, nowStation + w); i++) {
+                if (!mark[i]) { // 커버되는 범위가 아니면 커버되게끔 표시
+                    mark[i] = true;
+                    markCount++;
+                }
+            }
+            if (stationLeft >= 1 && !mark[stationLeft]) q.offer(stationLeft);
+            if (stationRight <= n && !mark[stationRight]) q.offer(stationRight);
+        }
+        constructCount += ((n - markCount)%w == 0)? (n-markCount)/w:(n-markCount)/w+1;
+        // System.out.println(Arrays.toString(mark));
+        // System.out.println(markCount);
+        // System.out.println(constructCount);
+
+        return constructCount;
+    }
+
+    boolean[] makeMark(int n, int[] stations, int w) {
+        boolean[] mark = new boolean[n+1];  // 전파가 커버하는 영역을 표시하는 배열
+        for (int i = 0; i < stations.length; i++) {
+            for (int j = Math.max(1, stations[i] - w); j <= Math.min(n, stations[i] + w); j++) mark[j] = true;
+        }
+
+
+        return mark;
+    }
+
+    Queue<Integer> makeInitStationsQueue(int n, int[] stations, int w) {
+        Queue<Integer> q = new ArrayDeque<>();  // 설치된 기지국의 범위를 벗어나는 왼쪽, 오른쪽에 기지국을 설치하는 것을 형상화하기 위해 큐를 이용
+        int stationLeft, stationRight;
+        for (int i = 0; i < stations.length; i++) {
+            stationLeft = stations[i] - (2*w+1);
+            stationRight = stations[i] + (2*w+1);
+            if (stationLeft >= 1) q.offer(stationLeft);
+            if (stationRight <= n) q.offer(stationRight);
+        }
+
+        return q;
+    }
+
+}

--- a/hoo/september/week3/PGMS_240918_기지국설치.java
+++ b/hoo/september/week3/PGMS_240918_기지국설치.java
@@ -1,7 +1,7 @@
 package september.week3;
 
-import java.util.ArrayDeque;
-import java.util.Queue;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PGMS_240918_기지국설치 {
 
@@ -12,58 +12,28 @@ public class PGMS_240918_기지국설치 {
     }
 
     int construct5G(int n, int[] stations, int w) {
-        int constructCount = 0;
+        int answer = 0;
+        List<Integer> neededLength = calcNeededLength(n, stations, w);
+        int nowNeed;
+        for (int i = 0; i < neededLength.size(); i++) { // 기지국이 커버하지 못하는 범위들에 대해서
+            nowNeed = neededLength.get(i);
 
-        int markCount = 0;
-        boolean[] mark = makeMark(n, stations, w);
-        for (int i = 1; i <= n; i++) if (mark[i]) markCount++;
-        Queue<Integer> q = makeInitStationsQueue(n, stations, w);
-
-        int nowStation;
-        int stationLeft, stationRight;
-        while (!q.isEmpty() && markCount < n) {
-            nowStation = q.poll();
-            stationLeft = nowStation - (2*w+1);
-            stationRight = nowStation + (2*w+1);
-            constructCount++;
-            for (int i = Math.max(1, nowStation - w); i <= Math.min(n, nowStation + w); i++) {
-                if (!mark[i]) { // 커버되는 범위가 아니면 커버되게끔 표시
-                    mark[i] = true;
-                    markCount++;
-                }
-            }
-            if (stationLeft >= 1 && !mark[stationLeft]) q.offer(stationLeft);
-            if (stationRight <= n && !mark[stationRight]) q.offer(stationRight);
+            answer += (nowNeed%(2*w+1) == 0)? nowNeed/(2*w+1):nowNeed/(2*w+1)+1;    // 그 범위들의 길이를 커버할 수 있는 기지국의 최소 개수를 정답에 더해줌
         }
-        constructCount += ((n - markCount)%w == 0)? (n-markCount)/w:(n-markCount)/w+1;
-        // System.out.println(Arrays.toString(mark));
-        // System.out.println(markCount);
-        // System.out.println(constructCount);
 
-        return constructCount;
+        return answer;
     }
 
-    boolean[] makeMark(int n, int[] stations, int w) {
-        boolean[] mark = new boolean[n+1];  // 전파가 커버하는 영역을 표시하는 배열
-        for (int i = 0; i < stations.length; i++) {
-            for (int j = Math.max(1, stations[i] - w); j <= Math.min(n, stations[i] + w); j++) mark[j] = true;
+    List<Integer> calcNeededLength(int n, int[] stations, int w) {
+        List<Integer> neededLength = new ArrayList<>(); // 초기에 기지국들이 커버하는 범위를 제외한, 전파를 전달해야 하는 곳의 길이를 저장할 리스트
+        if (stations[0]-(w+1) >= 1) neededLength.add(stations[0]-(w+1));    // 첫 기지국 전까지 전파가 안닿는 길이 삽입
+        for (int i = 1; i < stations.length; i++) {
+            if ((stations[i-1]+(w+1)) <= (stations[i]-(w+1))) neededLength.add((stations[i]-w) - (stations[i-1]+(w+1))); // 이전 기지국과 지금 기지국의 범위가 커버하지 못하는 범위가 있다면 리스트에 넣어줌
         }
 
+        if (stations[stations.length-1]+(w+1) <= n) neededLength.add(n - (stations[stations.length-1]+w)); // 마지막 기지국에서 마지막 아파트까지 범위 중 전파가 안닿는 길이 삽입
 
-        return mark;
-    }
-
-    Queue<Integer> makeInitStationsQueue(int n, int[] stations, int w) {
-        Queue<Integer> q = new ArrayDeque<>();  // 설치된 기지국의 범위를 벗어나는 왼쪽, 오른쪽에 기지국을 설치하는 것을 형상화하기 위해 큐를 이용
-        int stationLeft, stationRight;
-        for (int i = 0; i < stations.length; i++) {
-            stationLeft = stations[i] - (2*w+1);
-            stationRight = stations[i] + (2*w+1);
-            if (stationLeft >= 1) q.offer(stationLeft);
-            if (stationRight <= n) q.offer(stationRight);
-        }
-
-        return q;
+        return neededLength;
     }
 
 }

--- a/hoo/september/week3/PGMS_240918_기지국설치_실패코드.java
+++ b/hoo/september/week3/PGMS_240918_기지국설치_실패코드.java
@@ -1,0 +1,69 @@
+package september.week3;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class PGMS_240918_기지국설치_실패코드 {
+
+    public int solution(int n, int[] stations, int w) {
+        int answer = construct5G(n, stations, w);
+
+        return answer;
+    }
+
+    int construct5G(int n, int[] stations, int w) {
+        int constructCount = 0;
+
+        int markCount = 0;
+        boolean[] mark = makeMark(n, stations, w);
+        for (int i = 1; i <= n; i++) if (mark[i]) markCount++;
+        Queue<Integer> q = makeInitStationsQueue(n, stations, w);
+
+        int nowStation;
+        int stationLeft, stationRight;
+        while (!q.isEmpty() && markCount < n) {
+            nowStation = q.poll();
+            stationLeft = nowStation - (2*w+1);
+            stationRight = nowStation + (2*w+1);
+            constructCount++;
+            for (int i = Math.max(1, nowStation - w); i <= Math.min(n, nowStation + w); i++) {
+                if (!mark[i]) { // 커버되는 범위가 아니면 커버되게끔 표시
+                    mark[i] = true;
+                    markCount++;
+                }
+            }
+            if (stationLeft >= 1 && !mark[stationLeft]) q.offer(stationLeft);
+            if (stationRight <= n && !mark[stationRight]) q.offer(stationRight);
+        }
+        constructCount += ((n - markCount)%w == 0)? (n-markCount)/w:(n-markCount)/w+1;
+        // System.out.println(Arrays.toString(mark));
+        // System.out.println(markCount);
+        // System.out.println(constructCount);
+
+        return constructCount;
+    }
+
+    boolean[] makeMark(int n, int[] stations, int w) {
+        boolean[] mark = new boolean[n+1];  // 전파가 커버하는 영역을 표시하는 배열
+        for (int i = 0; i < stations.length; i++) {
+            for (int j = Math.max(1, stations[i] - w); j <= Math.min(n, stations[i] + w); j++) mark[j] = true;
+        }
+
+
+        return mark;
+    }
+
+    Queue<Integer> makeInitStationsQueue(int n, int[] stations, int w) {
+        Queue<Integer> q = new ArrayDeque<>();  // 설치된 기지국의 범위를 벗어나는 왼쪽, 오른쪽에 기지국을 설치하는 것을 형상화하기 위해 큐를 이용
+        int stationLeft, stationRight;
+        for (int i = 0; i < stations.length; i++) {
+            stationLeft = stations[i] - (2*w+1);
+            stationRight = stations[i] + (2*w+1);
+            if (stationLeft >= 1) q.offer(stationLeft);
+            if (stationRight <= n) q.offer(stationRight);
+        }
+
+        return q;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #75 

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 처음 시도한 풀이
  처음에는 각 주어진 각 기지국들이 커버하는 범위 양 옆에, 범위만큼을 한 번 더 띄운 위치에 기지국을 짓는 그리디한 방법으로 접근했습니다. 이를 통해 짓는다고 판단된 각 위치를 큐에 삽입, 이를 큐가 빌 때까지 수행해주었습니다. 큐가 모두 빈 후에도 커버하지 못하는 범위가 있다면 그를 범위*2+1로 나눈 것을 올림한 만큼을 정답에 더해주는 방식으로 풀이를 해보았습니다. 하지만 45점 정도 맞고 실패했고 경우를 떠올리기 힘들어 다른 방법으로 선회했습니다.

+ 이후의 풀이
  위의 아이디어와 비슷한 곳에서 아이디어를 착안했습니다. 결국 저희가 기지국을 지어야하는 곳은 맨 처음 지어져있던 기지국이 커버하지 못하는 곳들이므로, 이들의 길이를 재보자는 생각을 하게 되었습니다. 그리하여
  1. 기지국이 커버하지 못하는 곳들의 길이를 재고, 리스트에 저장하자
  2. 1번에서 구한 곳들을 기지국이 커버할 수 있는 범위인 w*2 + 1로 나눈 것을 올림한 값을 정답에 더해주자

  와 같은 방식으로 문제를 해결하였습니다

## 🧐 참고 사항


## 📄 Reference
