### PR TITLE
PGMS_240919_귤 고르기

### DIFF
--- a/hoo/september/week3/PGMS_240919_귤고르기.java
+++ b/hoo/september/week3/PGMS_240919_귤고르기.java
@@ -1,0 +1,56 @@
+package september.week3;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+public class PGMS_240919_귤고르기 {
+
+    class TangerineObject implements Comparable<TangerineObject> {
+        int number;
+        int count;
+
+        public TangerineObject(int number, int count) {
+            this.number = number;
+            this.count = count;
+        }
+
+        @Override
+        public int compareTo(TangerineObject t) {   // 개수 순 내림차순 정렬
+            return t.count - this.count;
+        }
+    }
+
+    public int solution(int k, int[] tangerine) {
+        int answer = findMinDiff(k, tangerine);
+
+        return answer;
+    }
+
+    int findMinDiff(int k, int[] tangerine) {
+        int maxTangerineNumber = 0; // 마지막 귤의 번호
+        Map<Integer, Integer> countMap = new HashMap<>();
+        for (int i = 0; i < tangerine.length; i++) {
+            if (countMap.containsKey(tangerine[i])) countMap.put(tangerine[i], countMap.get(tangerine[i]) + 1);
+            else countMap.put(tangerine[i], 1);
+            maxTangerineNumber = Math.max(maxTangerineNumber, tangerine[i]);
+        }
+
+        PriorityQueue<TangerineObject> pq = new PriorityQueue<>();
+        for (int i = 1; i <= maxTangerineNumber; i++) {
+            if (countMap.containsKey(i)) pq.offer(new TangerineObject(i, countMap.get(i)));
+        }
+
+        int answer = 0;
+        TangerineObject now;
+        while (!pq.isEmpty()) {
+            now = pq.poll();
+            answer++;
+            k -= now.count;
+            if (k <= 0) break;  // 귤 할당량 다 채웠다면 바로 종료
+        }
+
+        return answer;
+    }
+
+}

--- a/hoo/september/week3/PGMS_240920_불량사용자.java
+++ b/hoo/september/week3/PGMS_240920_불량사용자.java
@@ -1,0 +1,50 @@
+package september.week3;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class PGMS_240920_불량사용자 {
+
+    Set<String> patternMatchSet;
+
+    public int solution(String[] user_id, String[] banned_id) {
+        patternMatchSet = new HashSet<>();
+        findSamePattern(user_id, banned_id, 0, new boolean[user_id.length]);
+        int answer = patternMatchSet.size();
+
+        return answer;
+    }
+
+    void findSamePattern(String[] user_id, String[] banned_id, int count, boolean[] isSelected) {
+        if (count == banned_id.length) {    // 기저, 유저 아이디 중 banned_id 만큼을 골라서 정렬했을 때
+            String patternMatchString = "";
+            for (int i = 0; i < isSelected.length; i++) {
+                if (isSelected[i]) patternMatchString += user_id[i];
+            }
+            patternMatchSet.add(patternMatchString);    // 문제에서 순서는 중요하지 않다고 했으므로, 중복되는 것들 걸러주기 위해 Set에 저장
+
+            return;
+        }
+
+        String banned = banned_id[count];
+        String user;
+        boolean isSame;
+        for (int i = 0; i < user_id.length; i++) {
+            user = user_id[i];
+            isSame = true;
+            if (user.length() != banned.length() || isSelected[i]) continue; // 지금 매칭시킬 banned_id와 다른 유저 아이디는 탐색하지 않음, 또한 이미 고른 유저는 고려 대상이 아님
+            for (int j = 0; j < user.length(); j++) {
+                if (banned.charAt(j) == '*') continue;    // *은 와일드카드니까 비교 안해도 됨
+                else if (banned.charAt(j) != user.charAt(j)) {  // 같은 id 아니면 다음 id 탐색
+                    isSame = false;
+                    break;
+                }
+            }
+            if (!isSame) continue;  // 같은 id 아니면 다음 id 탐색
+            isSelected[i] = true;
+            findSamePattern(user_id, banned_id, count+1, isSelected);
+            isSelected[i] = false;
+        }
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #78 

## 📝 문제 풀이 전략 및 실제 풀이 방법
최소 크기 종류로 k를 충족하기 가장 좋은 방법은, 가장 개수가 많은 크기의 귤을 우선적으로 고르는 것이라고 생각했습니다. 이를 위해서 필요한 작업은
1. 주어진 귤들에 대해 크기 별로 개수를 카운트 한다
2. 1에서 구한 귤의 크기별 개수에 대해, 개수 기준 내림차순으로 k개를 충족할 때까지 카운트해준다

였습니다. 이를 위해 tangerine 배열에 대해 한 번의 반복을 수행해 Map에 크기 별 개수를 카운트, 그 후 가장 큰 크기의 귤까지 for문을 돌며(사실 이건 map의 key에 대해 iteration을 해주면 될 것 같은데 사용법을 몰라서 for문으로 구현했습니다) priority queue에 삽입해주었습니다. 이때 개수별 내림차순 적용을 위해 TagerineObject라는 class를 선언해주었습니다.
마지막으로 priority queue가 빌 때까지 원소를 추출하여 k에서 귤의 개수를 빼주며 뽑은 귤마다 answer의 카운트를 1씩 증가시켰습니다. 이때 k가 0이하가 된다면 바로 반복문 수행을 종료시켜주었습니다.


ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ절취선ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ

불량 사용자

이 문제는 user_id를 banned_id에 맞게끔 매치시키는 백트래킹으로 해결했습니다. 과정은
1. count 파라미터가 banned_id의 개수가 됐을 때를 기저로 잡음
2. 기저 달성 전까지는 user_id에 대해 반복하며 banned_id[count]와 패턴이 일치하는 지 판단
3. 패턴이 일치하지 않으면 다음 user_id를 탐색(백트래킹 요소)
4. 패턴이 일치하면 다음 재귀로 들어감

과 같습니다. 이를 통해 기저에 도달했을 때 주의해야 하는 점이 있는데요, 중복을 제거해야 하는 것이었습니다. 문제에서 "순서가 상관없다"고 했으므로, banned_id의 패턴에 의해 같은 user_id들이 뽑혔을 수도 있는 경우를 잘 다뤄줘야 하는 것입니다.
이를 위해 패턴이 일치한다고 표시한 user_id들을 하나의 String으로 합쳐 Set에 저장하여 중복을 제거한 후, Set의 크기를 정답으로 반환해주는 방식으로 해결하였습니다🩵💙💜

## 🧐 참고 사항

## 📄 Reference
