### PR TITLE
PGMS 240920 불량사용자

### DIFF
--- a/hyun/september/PGMS_240920_불량사용자.java
+++ b/hyun/september/PGMS_240920_불량사용자.java
@@ -1,0 +1,76 @@
+package backtracking;
+
+import java.util.*;
+
+public class PGMS_240920_불량사용자 {
+    String[] users;
+    String[] bans;
+    ArrayList<Node>[] banList;
+    HashMap<Integer, Integer> ansList = new HashMap<>();
+
+    int answer = 0;
+
+    class Node{
+        String ban;
+        int idx;
+        Node(String ban, int idx){
+            this.ban = ban;
+            this.idx = idx;
+        }
+    }
+
+    public void makeBanList(){
+        for(int a=0; a<bans.length; a++){
+            String banned = bans[a];
+
+            for(int b =0; b<users.length; b++){
+                String user = users[b];
+                if(banned.length() == user.length()){
+                    boolean isPossible = true;
+                    for(int i=0; i<banned.length(); i++){
+                        if(banned.charAt(i) == '*') continue;
+                        if(user.charAt(i) != banned.charAt(i)){
+                            isPossible = false;
+                            break;
+                        }
+                    }
+                    if(isPossible) banList[a].add(new Node(user, b));
+                }
+            }
+        }
+    }
+
+    public void dfs(int cnt, int made){
+        if(cnt == bans.length){
+            if(!ansList.containsKey(made)) ansList.put(made,1);
+            return;
+        }
+
+        for(int i=0; i<banList[cnt].size(); i++){
+            Node cur = banList[cnt].get(i);
+
+            if((made & (1 << cur.idx)) != 0 ) continue;
+            int tmp = made | (1<<cur.idx);
+            dfs(cnt+1, tmp);
+        }
+    }
+
+    public int simulation(){
+
+        makeBanList();
+
+        dfs(0,0);
+
+        return ansList.size();
+
+    }
+    public int solution(String[] user_id, String[] banned_id) {
+        users = user_id;
+        bans = banned_id;
+        banList = new ArrayList[banned_id.length];
+        for(int i=0; i<banned_id.length; i++) banList[i] = new ArrayList<>();
+
+
+        return simulation();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#81 

## 📝 문제 풀이 전략 및 실제 풀이 방법
banned_id 배열에서 각 자리에 대한 가능한 사용자를 모두 저장하는 배열을 만들어줍니다.
0번째는 -> frodo, fradi 가능 이런식으로 저장해두었습니다. 이때, 이름만 저장하는것이 아니라 나중에 중복제거를 위한 user_id 인덱스도 함께 저장해두었습니다.
그다음, banned_id 갯수만큼 모든 조합을 구해주었습니다. 이때, 유의해야 할 점은 중복체크를 해야합니다. 
예로 들어서 1,3번째와 3,1번째는 똑같은 경우의 수 입니다. 저는 중복 제거를 위해 비트 연산을 사용했습니다 ..
1,3번째는 각 1,3번째 자리에 1을 더해주는 식으로 하고, hashMap 을 이용하여 만들어진 비트를 넣어주는 식으로 구성하였습니다.

## 🧐 참고 사항
갯수가 8이하여서 방문 배열로 하고 그 방문 배열을 순회하며 숫자를 만들어줘도 충분한데, 이 아이디어 자체를 생각을 못했습니다 ..?ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ 앞으로 성장할 일만 남았습니다아 ~❣️(?)

## 📄 Reference

