### PR TITLE
PGMS_240921_240922_뒤에 있는 큰 수 찾기 + PGMS_240923_배달 + PGMS_240924_연속 부분 수열 합의 개수

### DIFF
--- a/hoo/september/week3/PGMS_240921_240922_뒤에있는큰수찾기.java
+++ b/hoo/september/week3/PGMS_240921_240922_뒤에있는큰수찾기.java
@@ -1,0 +1,29 @@
+package september.week3;
+
+import java.util.Arrays;
+import java.util.Stack;
+
+public class PGMS_240921_240922_뒤에있는큰수찾기 {
+
+    public int[] solution(int[] numbers) {
+        int[] answer = findBehindBigNumber(numbers);
+
+        return answer;
+    }
+
+    int[] findBehindBigNumber(int[] numbers) {
+        int[] answer = new int[numbers.length];
+        Arrays.fill(answer, -1);    // 뒷 큰수가 없을 경우를 대비하여 원소들 -1로 초기화
+
+        Stack<Integer> stack = new Stack<>();   // 숫자들의 "인덱스"를 담을 스택
+        for (int i = 0; i < numbers.length; i++) {
+            while (!stack.isEmpty() && numbers[stack.peek()] < numbers[i]) {    // 스택에 인덱스가 들어 있고, 스택 가장 위의 인덱스에 해당하는 숫자가 현재(i) 숫자보다 작을 동안 반복(다른 말로 하면, 이전의 숫자들을 하나씩 뒤돌아보며 현재(i) 숫자가 뒷 큰 수일 동안만 반복)
+                answer[stack.pop()] = numbers[i];
+            }
+            stack.push(i);  // 스택에 인덱스 삽입
+        }
+
+        return answer;
+    }
+
+}

--- a/hoo/september/week4/PGMS_240923_배달.java
+++ b/hoo/september/week4/PGMS_240923_배달.java
@@ -1,0 +1,87 @@
+package september.week4;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+
+public class PGMS_240923_배달 {
+
+    class Road implements Comparable<Road> {
+        int from;
+        int to;
+        int hour;
+
+        public Road(int from, int to, int hour) {
+            this.from = from;
+            this.to = to;
+            this.hour = hour;
+        }
+
+        @Override
+        public int compareTo(Road r) {  // 걸리는 시간을 기준으로 오름차순 정렬
+            return this.hour - r.hour;
+        }
+
+        @Override
+        public String toString() { return this.from + " " + this.to + " " + this.hour; }
+    }
+
+    public int solution(int N, int[][] road, int K) {
+        int answer = calcPossibleDeliveries(N, road, K);
+
+        return answer;
+    }
+
+    int calcPossibleDeliveries(int N, int[][] road, int K) {
+        List<List<Road>> roadList = makeRoadList(N, road);
+        int[] minHourArr = new int[N+1]; // 각 도시까지 가는 데 걸리는 최단거리를 저장할 배열
+        int INF = 2000 * 10_000 + 1;
+        for (int i = 2; i <= N; i++) minHourArr[i] = INF;  // 자기 자신으로 가는 도로를 제외하고는 최댓값으로 초기화
+        PriorityQueue<Road> pq = new PriorityQueue<>();
+        Road initRoad;
+        for (int i = 0; i < roadList.get(1).size(); i++) { // 일단 주어진 도로를 이용해서 1번 마을과 이어진 마을까지 시간 갱신
+            initRoad = roadList.get(1).get(i);
+            minHourArr[initRoad.to] = Math.min(minHourArr[initRoad.to], initRoad.hour);
+            pq.offer(roadList.get(1).get(i));
+        }
+
+        Road now;
+        List<Road> nextRoadList;
+        while (!pq.isEmpty()) {
+            now = pq.poll();
+            if (minHourArr[now.to] < now.hour) continue;  // 이미 더 짧은 경로가 존재하는 경우면 무시
+
+            nextRoadList = roadList.get(now.to);
+            Road next;
+            for (int i = 0; i < nextRoadList.size(); i++) {
+                next = nextRoadList.get(i);
+                if (minHourArr[next.to] > minHourArr[now.to] + next.hour) {
+                    minHourArr[next.to] = minHourArr[now.to] + next.hour;
+                    pq.offer(next);
+                }
+            }
+        }
+
+        int answer = 0;
+        for (int i = 1; i <= N; i++) if (minHourArr[i] <= K) answer++;
+
+        return answer;
+    }
+
+    List<List<Road>> makeRoadList(int N, int[][] road) {
+        List<List<Road>> roadList = new ArrayList<>();
+        for (int i = 0; i <= N; i++) roadList.add(new ArrayList<>());
+
+        int from, to, hour;
+        for (int i = 0; i < road.length; i++) {
+            from = road[i][0];
+            to = road[i][1];
+            hour = road[i][2];
+            roadList.get(from).add(new Road(from, to, hour));
+            roadList.get(to).add(new Road(to, from, hour));
+        }
+
+        return roadList;
+    }
+
+}

--- a/hoo/september/week4/PGMS_240924_연속부분수열합의개수.java
+++ b/hoo/september/week4/PGMS_240924_연속부분수열합의개수.java
@@ -8,7 +8,6 @@ public class PGMS_240924_연속부분수열합의개수 {
     public int solution(int[] elements) {
         int answer = calcAnswer(elements);
 
-
         return answer;
     }
 
@@ -16,11 +15,13 @@ public class PGMS_240924_연속부분수열합의개수 {
         Set<Integer> sumSet = new HashSet<>();
         int sum;
         for (int i = 1; i <= elements.length; i++) { // elements의 길이만큼의 원소를 선택
-            for (int j = 0; j < elements.length; j++) { // elements의 처음부터 끝 원소까지
-                sum = 0;
-                for (int k = 0; k < i; k++) {  // 연속으로 i개를 선택해서 더해줌
-                    sum += elements[(j+k) % elements.length];
-                }
+            sum = 0;
+            for (int j = 0; j < i; j++) sum += elements[j];   // 우선 맨 첫수부터 연속한 i개를 모두 선택해서 만들 수 있는 합을 만들어 줌
+            sumSet.add(sum);
+
+            for (int j = 0; j < elements.length; j++) { // 이후 슬라이딩 윈도우 형식으로 옮겨가며 바뀐 연속 숫자들의 합을 계산
+                sum -= elements[j];
+                sum += elements[(j+i) % elements.length];
                 sumSet.add(sum);
             }
         }

--- a/hoo/september/week4/PGMS_240924_연속부분수열합의개수.java
+++ b/hoo/september/week4/PGMS_240924_연속부분수열합의개수.java
@@ -1,0 +1,31 @@
+package september.week4;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class PGMS_240924_연속부분수열합의개수 {
+
+    public int solution(int[] elements) {
+        int answer = calcAnswer(elements);
+
+
+        return answer;
+    }
+
+    int calcAnswer(int[] elements) {
+        Set<Integer> sumSet = new HashSet<>();
+        int sum;
+        for (int i = 1; i <= elements.length; i++) { // elements의 길이만큼의 원소를 선택
+            for (int j = 0; j < elements.length; j++) { // elements의 처음부터 끝 원소까지
+                sum = 0;
+                for (int k = 0; k < i; k++) {  // 연속으로 i개를 선택해서 더해줌
+                    sum += elements[(j+k) % elements.length];
+                }
+                sumSet.add(sum);
+            }
+        }
+
+        return sumSet.size();
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #82 

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 뒤에 있는 큰 수 찾기
우선 주어진 numbers의 길이(N)이 어마무시하게 크므로 최대 한 번의 반복문 안에서(O(N), O(logN), 계산은 안해봤는데 아마 O(NlogN)도 가능...?) 문제를 해결해야 합니다. 그런데 뒤에 있는 모든 수를 헤아려야 합니다. 그럼 한 번의 반복문 안에서 어딘가에 숫자를 저장해두고 뒤에 있는 수들과 비교를 해나가야한다라는 생각이 들었고, 저는 이런 느낌(?)의 문제에서는 스택을 떠올리는 편입니다.
  그럼 저에게 필요한 과정은
  1. 한 번의 반복문을 돌며 숫자들을 모두 스택에 넣는다
  2. 다음 숫자로 넘어갈 때마다 스택의 가장 상위에 있는 숫자들을 현재 숫자와 비교한다
  3. 스택 상위의 현재 숫자보다 작다면, 그 숫자 입장에서는 현재 숫자가 뒤에 있는 큰 수이므로, 스택에서 뽑아주고 answer 배열의 스택 상위 숫 
 자가 있던 자리에 현재 숫자를 저장해준다
  4. 2~3 과정을 스택이 비거나 스택 상위 숫자가 현재 숫자보다 작은 숫자일 동안 반복한다

  로 정리할 수 있습니다. 여기서 스택에 어떤 값을 넣어줄 지가 고민이었는데요, 숫자 그대로를 넣어준다면 그 숫자가 어느 위치에 있던 숫자인 지 알 수가 없었기 때문입니다. 그래서 저는 스택에는 숫자들의 인덱스를 넣어줬고, 그 인덱스를 가지고 numbers에서 값을 조회하는 방식으로 해결을 했답니다~

----------------------절취선-----------------------

+ 배달
  첨에는 1번 마을에서만 거리를 측정하면 되는 걸 간과하고 플로이드 워셜로 접근했다가, 작성 중에 1번 마을에서의 최단거리만 고려하면 되는 것을 알고는 다익스트라로 선회했습니다.
그렇게 1번 마을을 시작으로 다른 마을까지의 거리를 계산해주는 다익스트라로 풀었삼니다 하지만 다익스트라를 까먹어서 프린트 찍어가며 푸느라 애를 많이 먹었습니다 하하...

----------------------절취선-----------------------

+ 연속 부분 수열 합의 개수
  첫 풀이 방식은 무식하게 작성했습니다. 1개부터 elements의 길이만큼을 선택하는 경우를 순회하며, 숫자들을 2중 for문으로 합해주는 방식으로 수행하여 N^3의 시간복잡도를 가지는 풀이방식이었습니다. 정답을 받았지만? 어떻게 받았는 지 모르겠고 계산해보니 N^3은 10억의 크기를 가지므로 이건 문제를 해결한 게 아니라는 생각이 들었습니다. 
그리하여 이를 N^2으로 줄이는 방법을 생각해보았고, 슬라이딩 윈도우가 생각났습니다. 가장 바깥의 1개부터 elements의 길이만큼을 선택하는 for문은 유지한 채, 내부의 로직을 N^2에서
  1. 우선 맨 첫수부터 i개 만큼 연속한 수의 원소의 합을 구하고
  2. 그 합을 i개 만큼의 크기를 가진 슬라이딩 윈도우 방식으로 맨 끝수까지 옮겨가며 합을 구해준다

  와 같은 방식으로 변경, N으로 줄여 총 N^2의 시간복잡도를 가지는 로직으로 수정해보았습니다.

## 🧐 참고 사항

## 📄 Reference
