### PR TITLE
PGMS 240924 연속 부북 수열 합의 개수

### DIFF
--- a/hyun/september/PGMS_240924_연속부분수열합의개수.java
+++ b/hyun/september/PGMS_240924_연속부분수열합의개수.java
@@ -1,0 +1,25 @@
+package implementation;
+
+import java.util.*;
+
+public class PGMS_240924_연속부분수열합의개수 {
+    public int solution(int[] elements) {
+        Set<Integer> num = new HashSet<>();
+
+        for(int i=0; i<elements.length; i++){
+            int sum = 0;
+            int idx = i;
+            for(int k=1; k<elements.length; k++){
+                sum += elements[idx];
+                idx = (idx+1)%elements.length;
+                num.add(sum);
+            }
+        }
+
+        int sum = 0;
+        for(int su : elements) sum += su;
+        num.add(sum);
+
+        return num.size();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#87 


## 📝 문제 풀이 전략 및 실제 풀이 방법
### 구현
n 개의 길이만큼 계속 더해주어서 Set 에 넣어주는 식으로 구현했습니다. 

1. 입력값을 기준으로 반복문을 돌며
2. 길이가 1 ~ 입력값 배열 길이 -1 만큼의 길이만큼 현재 입력값 위치에서 계속 하나씩 더해주면서 Set 에 넣었습니다 !
정답은 Set 사이즈 출력 해주었습니도오옹

## 🧐 참고 사항
.

## 📄 Reference
.
