### PR TITLE
PGMS_240925_보석 쇼핑

### DIFF
--- a/hoo/september/week4/PGMS_240925_보석쇼핑.java
+++ b/hoo/september/week4/PGMS_240925_보석쇼핑.java
@@ -1,0 +1,60 @@
+package september.week4;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PGMS_240925_보석쇼핑 {
+
+    public int[] solution(String[] gems) {
+        int[] answer = findAnswer(gems);
+
+        return answer;
+    }
+
+    int[] findAnswer(String[] gems) {
+        Map<String, Integer> gemsMap = new HashMap<>();
+        int gemVaries = 0;  // 보석 종류의 수
+        String gem;
+        for (int i = 0; i < gems.length; i++) { // map에 보석의 이름을 key로하는 값들 저장
+            gem = gems[i];
+            if (!gemsMap.containsKey(gem)) {
+                gemsMap.put(gem, 0);
+                gemVaries++;
+            }
+        }
+
+        int[] answer = new int[2]; // 정답 배열
+        int minAnswerLength = Integer.MAX_VALUE;    // 모든 보석을 다 가지는 경우 중 가장 짧은 구간의 길이를 저장할 변수
+
+        int right = 0, left = 0;
+        String rightGem, leftGem;
+        rightGem = gems[right];
+        leftGem = gems[left];
+        gemsMap.put(rightGem, 1);
+        int tempGemVaries = 1;  // 가변 슬라이딩 윈도우 내에 있는 보석 종류의 수
+        while (left <= gems.length-1) { // 보석 수를 충족한 경우 최소 구간 비교를 위해 왼쪽 포인터가 마지막에 도달했을 때까지 반복문 수행
+            if (tempGemVaries == gemVaries) {   // 모든 보석 종류를 다 가졌을 때
+                if (minAnswerLength > right - left) {
+                    answer = new int[] {left+1, right+1};
+                    minAnswerLength = right - left;
+                }
+            }
+            if (left == gems.length - 1) break; // 왼쪽 포인터가 마지막에 도달한 경우 반복 종료
+
+            if (left == right || (tempGemVaries < gemVaries && right < gems.length - 1)) {    // 왼쪽 포인터와 오른쪽 포인터 위치가 같거나 / 보석 종류수가 부족하고, 오른쪽 포인터가 끝까지 가지 않은 경우 우측 포인터 이동
+                right++;
+                rightGem = gems[right];
+                gemsMap.put(rightGem, gemsMap.get(rightGem) + 1);
+                if (gemsMap.get(rightGem) == 1) tempGemVaries++;
+            } else if (tempGemVaries == gemVaries || right == gems.length - 1) { // 보석 종류수가 채워져있거나 / 오른쪽 포인터가 끝까지 도달한 경우
+                gemsMap.put(leftGem, gemsMap.get(leftGem) - 1); // 왼쪽 포인터가 가르키던 보석의 개수 -1
+                if (gemsMap.get(leftGem) == 0) tempGemVaries--; // 그때 그 보석을 가진 개수가 0이면 보석 종류 수 -1
+                left++; // 왼쪽 포인터 이동
+                leftGem = gems[left];
+            }
+        }
+
+        return answer;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #89 

## 📝 문제 풀이 전략 및 실제 풀이 방법
구간에 들어있는 것의 조건을 따지고, 그 조건을 만족하는 최소 길이 구간을 찾는 문제였습니다. 저는 이런 문제에서 투 포인터를 활용하여 가변 슬라이딩 윈도우 형식으로 문제를 풀이합니다. 이 문제도 그런 방식으로 해결했고, 보석의 종류를 카운트하기 위해 Map에 현재 구간 내 보석의 개수를 저장해주고 이용했습니다.
Map에는 보석의 이름을 key로 하고, 구간 내 각 보석의 개수를 저장해줍니다. 한 구간 내 보석의 종류 수는 Map에서 value가 0이 아닌 보석들의 수입니다. left, right 포인터를 선언, 모두 0에서 시작하고 처음 구간 내 보석의 종류 수는 1입니다. 이후의 반복문에서 진행 방식은
1. 반복문의 시작 부분에서 모든 보석을 가지고 있는 지 체크합니다. 이 경우 구간의 길이가 이전 최소 구간 길이보다 짧다면 구간을 갱신해줍니다.
2. left 포인터 위치와 right 포인터 위치가 같은 지 or 모든 종류의 보석을 가지고 있으면서 right 포인터가 배열의 마지막에 다다르지 않았는 지 체크합니다.
  2.1 이 경우 right 포인터를 우측으로 이동, 새로 가르키는 보석의 value를 map에서 찾아 +1 해줍니다.
  2.2 이때 map에서의 value가 1이라면 구간 내 보석의 종류를 +1 해줍니다.
3. 2번 경우가 아닌 경우, 즉 left와 right 포인터가 가르키는 보석이 같지 않고, 구간이 모든 보석을 포함하지 못하거나 우측 포인터가 끝에 다다른 경우에는
  3.1 left 포인터를 우측으로 이동, 이전에 가르켰던 보석의 value를 map에서 찾아 -1 해줍니다.
  3.2 이때 map에서의 value가 0이라면 구간 내 보석의 종류를 -1 해줍니다.

와 같은 방식으로 left 포인터가 마지막에 다다랐을 때까지 반복문을 진행해주며, left포인터가 마지막에 다다랐을 경우 1번에서 수행하는 비교 후에 반복문 수행을 멈춰주는 방식으로 문제를 해결하였습니다.

## 🧐 참고 사항

## 📄 Reference
