### PR TITLE
PGMS_240928_240929_H-Index

### DIFF
--- a/hoo/september/week4/PGMS_240928_240929_HIndex.java
+++ b/hoo/september/week4/PGMS_240928_240929_HIndex.java
@@ -1,0 +1,29 @@
+package september.week4;
+
+import java.util.Arrays;
+
+public class PGMS_240928_240929_HIndex {
+
+    public int solution(int[] citations) {
+        int answer = calcHIndex(citations);
+
+        return answer;
+    }
+
+    int calcHIndex(int[] citations) {
+        Arrays.sort(citations);
+
+        int answer = 0;
+        int overHLength;
+        for (int i = 0; i < citations.length; i++) {
+            overHLength = citations.length - i; // 현재 체크할 인덱스 이상인 수들의 개수
+            if (citations[i] > overHLength) {   // overHLength가 더 작은 수인 경우
+                answer = Math.max(answer, overHLength);
+            } else answer = Math.max(answer, citations[i]); // citation이 더 작은 수인 경우
+        }
+
+
+        return answer;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #98 

## 📝 문제 풀이 전략 및 실제 풀이 방법
우와 너무 어려웠어요.. 주어진 예제로만 생각하다가 그게 아닌가? 하고 시도해본 방법이 통해서 우연히 풀었습니다...
문제에서 주어진 문제를 봤을 때는 주어진 인용 횟수 중에서 H Index를 골라야하는 것처럼 보였습니다. 그렇지만 계속 틀리길래 뭐가 문젠가 하고 생각하다가, 주어진 횟수가 아니라도 H Index로 판명될 수 있겠다는 생각을 하고는 이를 따져주게 되었습니다.
이걸 따져주기 위해 저는 배열을 오름차순 정렬해준 상태에서 for문으로 조회를 돌며
+ 현재 인용 횟수부터 뒷 인용 횟수들의 개수(citations.length - i)와
+ 현재 인용 횟수(citations[i]) 중 작은 수를 골라
+ 현재 저장된 answer와 비교를 해주어 큰 수를 answer로 저장해주었습니다.

이때 citations[i]와 citations.length-i 중 작은 수를 골라야 하는 이유는, 큰 수를 골라 진행하면 인용횟수가 H 이상인 인용들의 개수가 H 이상임을 충족하지 못하기 때문입니다. 
그리고 answer과 비교를 할 때 더 큰 수를 골라야 하는 이유는, 이전 진행에서 현재 진행에서 얻은 H Index보다 큰 수를 얻었을 수도 있음을 고려한 것입니다. 예를 들어, 저장된 H-Index가 citations[i]에서 얻어진 수인데, citations.length - j가 H Index로 적합한 경우가 더 나중에 판단이 되고, 이때 citations[i]가 citations.length - j 보다 클 수있기 때문입니다. 사실 이 answer의 갱신 시 Math.max() 처리는 citations.length - i를 갱신할 때만 따져주면 될 것 같다는 생각이 있지만, 혹시 몰라 두 경우 모두에 Math.max() 처리를 해주었습니다.

## 🧐 참고 사항


## 📄 Reference
