### PR TITLE
PGMS_240928_240929_H-Index

### DIFF
--- a/hyun/september/PGMS_240928_240929_HIndex.java
+++ b/hyun/september/PGMS_240928_240929_HIndex.java
@@ -1,0 +1,41 @@
+package implementation;
+
+import java.util.*;
+public class PGMS_240928_240929_HIndex {
+    public int solution(int[] citations) {
+        int answer = 0;
+
+        Arrays.sort(citations);
+
+        int idx = 0;
+        int su = -1;
+
+        for(int h=0; h<=citations.length; h++){
+            if(citations[idx] == h){
+                //System.out.println("--h " + h + " idx " + idx + " su " + su);
+                if((citations.length - idx) >= h && su != citations[idx]) {
+                    answer = h;
+                    su = citations[idx];
+                }
+
+                boolean isChange = false;
+                for(int j=idx; j<citations.length; j++){
+                    if(citations[j] != su){
+                        idx = j;
+                        isChange = true;
+                        break;
+                    }
+                }
+                if(!isChange) break;
+            }
+            else{
+                //System.out.println("h " + h + " idx " + idx + " su " + su);
+                if((citations.length - idx) >= h) answer = h;
+            }
+
+
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#98 

## 📝 문제 풀이 전략 및 실제 풀이 방법
입력 배열을 오름차순 해준 뒤, h 를 0 ~ citations 길이 로 설정하여 문제에서 주어진 조건 ( h번 이상 인용된 논문이 h편 이상 ) 을 만족한다면 정답에 h를 갱신해주는 식으로 구현했습니다. 여기서 h는 점점 커질것이므로 정답 갱신할때는 answer = h 이렇게 바로 갱신해주었습니다.

h를 설정해주고 모든 citations 을 봐주게 되면 시간초과가 나기 때문에 h를 봐주는 동시에 citations 배열의 길이 계산을 한번에 처리해주어야 했습니다.

![image](https://github.com/user-attachments/assets/1dd29950-d278-4edc-a995-ccfd4cb05a47)

위의 그림의 왼쪽 파란글씨처럼 h 가 2 라면 인덱스 1,2 사이에 h가 위치하게 된다는 것을 알게됩니다. 그럼 인덱스 위치가 2라면 citations - 인덱스만 해주면 h번 이상 인용된 논문이 h편 이상이라는 계산이 한번 됩니다. 이 과정을 녹여서 구현할려구 힘썼습니다 !!!

그래서 구현하는 과정이 조금 까다로웠습니다 ..

### 구현과정
for문으로 h = 0 ~ citations 의 길이만큼 순회하면서, citations 의 순회를 위한 포인터 idx, 현재 citations의 수 su 를 따로 두었습니다. 
이때 만약 citations[idx] == h 가 일치하고, su 가 현재 citations[idx] 가 다르면 , 정답을 갱신해줍니다.
여기서 su 가 현재 citations[idx] 랑 다른지 봐주는 이유는 입력 배열에 중복값이 있을 수 있기 떄문입니다. 
예를 들어 [ 0, 1, 1 ]이 입력값인 경우 단순히  citations[idx] == h 만 조건문으로 둘경우 idx ++ 하게 되어 h번 이상 인용된 논문의 길이를 구할때 오류가 납니다. 이 배열에선 인덱스가 1 , 2의 배열 값은 모두 1 이므로 길이 계산은 동일해야합니다.
그다음으로 idx 를 갱신해줄때 현재 su 와 citations[idx] 가 다를때까지 idx 를 +1 해줍니다. ( 중복값을 다 뛰어넘기 위해 )




## 🧐 참고 사항
.

## 📄 Reference
.
