### PR TITLE
PGMS_240930_줄서는방법

### DIFF
--- a/hyun/september/PGMS_240930_줄서는방법.java
+++ b/hyun/september/PGMS_240930_줄서는방법.java
@@ -1,0 +1,52 @@
+package implementation;
+
+public class PGMS_240930_줄서는방법 {
+    int[] answer;
+    int N;
+    long K;
+    long[] fac;
+
+    public boolean perm(boolean[] selected, int digit){
+        if(K==1 && digit == N){
+            for(int i=1; i<=N; i++){
+                if(!selected[i]){
+                    answer[digit-1] = i;
+                    break;
+                }
+            }
+
+            return true;
+        }
+
+        for(int i=1; i<=N; i++){
+            if(selected[i]) continue;
+            else{
+                if((K - fac[(N-digit)]) > 0){
+                    K -= fac[(N-digit)];
+                }
+                else{
+                    selected[i] = true;
+                    answer[digit-1] = i;
+                    if(perm(selected, digit + 1)) return true;
+                }
+            }
+
+        }
+
+        return true;
+    }
+
+
+    public int[] solution(int n, long k) {
+        answer = new int[n];
+        N = n;
+        K = k;
+        fac = new long[n+1];
+        fac[1] = 1;
+        for(int i=2; i<= n; i++) fac[i] = fac[i-1] * i;
+
+        perm(new boolean[n+1], 1);
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#100 

## 📝 문제 풀이 전략 및 실제 풀이 방법
순열을 모두 돌면서 k번째를 구하면 시간초과가 날 것이라고 생각했습니다. ( 최대 20! 이므로)
그래서 한번에 구하는 방법이 뭐가 있을까 생각 하다가, 맨 왼쪽부터 하나씩 선택해가면서 경우의 수를 일일이 빼주면서 k번째를 구하는 방법을 생각했습니다.

순열을 dfs 를 활용해서 돌때 자릿수대로
현재 자릿수에 가능한 숫자를 선택하고 나머지 자릿수들의 경우의 수를 K 에서 뺴주었을때 0보다 크다면 숫자를 계속 늘려주었습니다.
이때, 0보다 이하이면 다음 자릿수의 숫자를 선택하러 가주었습니다. 
이렇게 순열을 돌다가 K 가 총 1 이 남고 자릿수가 마지막 자릿수를 가르킬때, 선택되지 않은 숫자를 선택하여 마지막 정답 배열에 넣어주었습니다. 이렇게 정답이 갱신되면 true 를 반환해서 함수가 더 재귀를 돌지 않게끔 구성하였습니다.

## 🧐 참고 사항
.

## 📄 Reference
.
