### PR TITLE
PGMS_241001_연도별 대장균 크기의 편차 구하기

### DIFF
--- a/hoo/september/week5/PGMS_241001_연도별대장균크기의편차구하기
+++ b/hoo/september/week5/PGMS_241001_연도별대장균크기의편차구하기
@@ -1,0 +1,9 @@
+-- 코드를 작성해주세요
+select YEAR(a.differentiation_date) as YEAR, (b.size - a.size_of_colony) as YEAR_DEV, a.id as ID
+from ecoli_data as a
+join (
+    select MAX(size_of_colony) as size, YEAR(differentiation_date) as year_in  # 연도 별 최대 크기 가져오는 쿼리
+    from ecoli_data
+    group by year_in) as b
+on YEAR(a.differentiation_date) = b.year_in
+order by YEAR asc, YEAR_DEV asc;


### PR DESCRIPTION
## 🔍 개요
+ #104 

## 📝 문제 풀이 전략 및 실제 풀이 방법
우선 분화된 년도별 분류가 필요하기 때문에 differentiation_date의 YEAR를 이용하기 위해 YEAR() 함수를 이용하고, 그에 따라 그룹을 만들어줍니다. 그 후 그 그룹에서 가장 큰 대장균의 크기를 골라내기 위하여 MAX() 함수를 이용해 size_of_colony의 최댓값을 조회해줍니다.
위의 과정을 거쳐 각 년도별 최대 크기 대장균의 크기와 년도를 조회해왔습니다. 이제 필요한 건 문제에서 요구한 YEAR_DEV를 구하는 것인데요, 저는 이를 위해 join을 이용했습니다. 원본 테이블과 위에서 조회한 테이블을 year이 같은 행을 기준으로 하나의 테이블로 합쳐주고, 원본 테이블의 각 size_of_coloney를 위에서 조회해온 테이블의 MAX(size_of_colony)에서 빼준 값을 출력해주면 됩니다. 정렬은 단순히 YEAR asc, YEAR_DEV asc로 처리해주면 됩니다!

## 🧐 참고 사항

## 📄 Reference
