### PR TITLE
PGMS 241002 연속된 부분 수열의 합

### DIFF
--- a/hyun/10_october/PGMS_241002_연속된부분수열의합.java
+++ b/hyun/10_october/PGMS_241002_연속된부분수열의합.java
@@ -1,0 +1,29 @@
+package two_pointer;
+
+public class PGMS_241002_연속된부분수열의합 {
+    int[] answer = {0,1000010};
+    public int[] solution(int[] sequence, int k) {
+        int sum = 0;
+        int left = 0;
+
+        for(int right = 0; right < sequence.length; right++){
+            sum += sequence[right];
+
+            if(sum == k){
+                if(answer[1] - answer[0] > right - left) answer = new int[]{left,right};
+            }
+            else if(sum > k){
+                while(true){
+                    sum -= sequence[left++];
+
+                    if(sum <= k){
+                        if(sum == k) if(answer[1] - answer[0] > right - left) answer = new int[]{left,right};
+                        break;
+                    }
+                }
+            }
+        }
+
+        return answer;
+    }
+}

--- a/hyun/10_october/PGMS_241003_피로도.java
+++ b/hyun/10_october/PGMS_241003_피로도.java
@@ -1,0 +1,31 @@
+package implementation;
+
+public class PGMS_240930_줄서는방법 {
+    int K;
+    int[][] input;
+    int answer = 0;
+
+    public void perm(boolean[] selected, int cnt, int tired){
+        answer = Math.max(answer, cnt);
+
+        for(int i=0; i<input.length; i++){
+            if(selected[i]) continue;
+
+            if(tired >= input[i][0]){
+                selected[i] = true;
+                perm(selected, cnt + 1, tired - input[i][1]);
+                selected[i] = false;
+            }
+
+        }
+    }
+
+    public int solution(int k, int[][] dungeons) {
+        K = k;
+        input = dungeons;
+
+        perm(new boolean[dungeons.length], 0,k);
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#107 


## 📝 문제 풀이 전략 및 실제 풀이 방법
------------------------------------------------------연속된 부분 수열의 합
### 투포인터
left, right 를 두어 right기준으로 입력 배열을 순회합니다.
sum 이라는 변수를 두어 right 를 더했을때,
1. sum == k 이면 정답을 구간이 더 짧은 구간으로 갱신합니다.
2. sum > k 라면 left 를 sum 이 k보다 이하일때까지 +1 시켜줍니다. 이때, sum == k 라면 정답을 갱신합니다.

------------------------------------------------------피로도
### 순열
입력 배열값을 순열로 조합하면서 피로도를 계산합니다.
이때, 재귀를 돌때 먼저 정닶값을 cnt 가 제일 큰것으로 갱신해주었습니다.

## 🧐 참고 사항
.

## 📄 Reference
.
