### PR TITLE
PGMS_241004_스티커 모으기

### DIFF
--- a/hoo/september/week5/PGMS_241004_스티커모으기.java
+++ b/hoo/september/week5/PGMS_241004_스티커모으기.java
@@ -1,0 +1,38 @@
+package september.week5;
+
+public class PGMS_241004_스티커모으기 {
+
+    public int solution(int sticker[]) {
+        int answer = calcMaxSticker(sticker);
+
+        return answer;
+    }
+
+    int calcMaxSticker(int sticker[]) {
+        if (sticker.length == 1) return sticker[0]; // 내 일반식은 길이가 3인 것부터 유효하므로 길이가 1, 2일 때는 조건문으로 처리해주기
+        else if (sticker.length == 2) return Math.max(sticker[0], sticker[1]);
+
+        int[] firstSelectedSticker = new int[sticker.length-1];
+        int[] secondSelectedSticker = new int[sticker.length-1];
+        for (int i = 0; i < sticker.length-1; i++) {
+            firstSelectedSticker[i] = sticker[i];
+            secondSelectedSticker[i] = sticker[i+1];
+        }
+        int firstMax = dynamicProgramming(firstSelectedSticker);
+        int secondMax = dynamicProgramming(secondSelectedSticker);
+
+        return Math.max(firstMax, secondMax);
+    }
+
+    int dynamicProgramming(int sticker[]) { // 첫 번째, 두 번째 스티커를 사용한 경우에 따라 다른 배열을 가지고 dp를 수행
+        int[] dpArr = new int[sticker.length];
+        dpArr[0] = sticker[0];
+        dpArr[1] = Math.max(dpArr[0], sticker[1]);
+        for (int i = 2; i < sticker.length; i++) {
+            dpArr[i] = Math.max(dpArr[i-2] + sticker[i], dpArr[i-1]);
+        }
+
+        return dpArr[sticker.length-1];
+    }
+
+}

--- a/hoo/september/week5/PGMS_241004_스티커모으기.java
+++ b/hoo/september/week5/PGMS_241004_스티커모으기.java
@@ -12,19 +12,19 @@ public class PGMS_241004_스티커모으기 {
         if (sticker.length == 1) return sticker[0]; // 내 일반식은 길이가 3인 것부터 유효하므로 길이가 1, 2일 때는 조건문으로 처리해주기
         else if (sticker.length == 2) return Math.max(sticker[0], sticker[1]);
 
-        int[] firstSelectedSticker = new int[sticker.length-1];
-        int[] secondSelectedSticker = new int[sticker.length-1];
-        for (int i = 0; i < sticker.length-1; i++) {
+        int[] firstSelectedSticker = new int[sticker.length-1]; // 첫 번째 스티커를 고른 경우의 배열
+        int[] lastSelectedSticker = new int[sticker.length-1];  // 마지막 스티커를 고른 경우의 배열
+        for (int i = 0; i < sticker.length-1; i++) {    // 각 배열 초기화
             firstSelectedSticker[i] = sticker[i];
-            secondSelectedSticker[i] = sticker[i+1];
+            lastSelectedSticker[i] = sticker[i+1];
         }
-        int firstMax = dynamicProgramming(firstSelectedSticker);
-        int secondMax = dynamicProgramming(secondSelectedSticker);
+        int firstMax = dynamicProgramming(firstSelectedSticker);    // 첫 번째 스티커를 고른 경우의 최댓값 계산
+        int lastMax = dynamicProgramming(lastSelectedSticker);    // 마지막 스티커를 고른 경우의 최댓값 계산
 
-        return Math.max(firstMax, secondMax);
+        return Math.max(firstMax, lastMax);
     }
 
-    int dynamicProgramming(int sticker[]) { // 첫 번째, 두 번째 스티커를 사용한 경우에 따라 다른 배열을 가지고 dp를 수행
+    int dynamicProgramming(int sticker[]) { // 첫 번째, 마지막 스티커를 사용한 경우에 따라 다른 배열을 가지고 dp를 수행
         int[] dpArr = new int[sticker.length];
         dpArr[0] = sticker[0];
         dpArr[1] = Math.max(dpArr[0], sticker[1]);


### PR DESCRIPTION
## 🔍 개요
+ #110 

## 📝 문제 풀이 전략 및 실제 풀이 방법
스티커가 연속으로 이어져 있기 때문에 첫 번째 스티커를 고르면 마지막 스티커를 못 고르며, 그 역도 성립합니다. 그리하여 첫 번째 스티커를 고르면 마지막 스티커가 없는 배열을 만들고, 마지막 스티커를 고를 수도 있는 경우를 고려하기 위해 첫 번째 스티커를 제거한 배열을 만들었습니다.
 이 두 배열을 이용하여 동적 프로그래밍을 두 번 수행, 그 값 중 최댓값을 리턴해주면 됩니다. 동적 프로그래밍의 일반식으로는
dpArr[i] = Math.max(현재 스티커와 전전 스티커까지의 합, 직전 스티커까지의 합)
을 세워주어 수행했습니다. 하지만 제 일반식의 경우 길이가 3 이상인 경우를 생각하고 만들었기 때문에 길이가 1, 2인 스티커들에 대해서는 조건문으로 처리를 해주었습니다.

## 🧐 참고 사항


## 📄 Reference
