### PR TITLE
PGMS 241007 스티커모으기

### DIFF
--- a/hyun/10_october/PGMS_241007_스티커모으기.java
+++ b/hyun/10_october/PGMS_241007_스티커모으기.java
@@ -1,0 +1,40 @@
+
+
+public class PGMS_241007_스티커모으기 {
+    int answer = 0;
+
+    public void simulation(int start, int end, int[] dp, int[] sticker){
+        for(int i=start; i<end; i++){
+            if(dp[i] == 0) dp[i] = sticker[i];
+
+            if(i+2 < end){
+                if(dp[i+2] < (dp[i] + sticker[i+2])){
+                    dp[i+2] = dp[i] + sticker[i+2];
+                }
+            }
+
+            if(i+3 < end){
+                if(dp[i+3] < (dp[i] + sticker[i+3])){
+                    dp[i+3] = dp[i] + sticker[i+3];
+                }
+            }
+
+            if(answer < dp[i]) answer = dp[i];
+        }
+    }
+
+    public int solution(int sticker[]) {
+        if(sticker.length == 1) return sticker[0];
+
+        int[] dp = new int[sticker.length];
+        int[] dp2 = new int[sticker.length];
+
+        dp[0] = sticker[0];
+        dp2[1] = sticker[1];
+
+        simulation(0, sticker.length-1, dp, sticker);
+        simulation(1, sticker.length, dp2, sticker);
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#110 


## 📝 문제 풀이 전략 및 실제 풀이 방법
처음엔, 정말 단순하게 인덱스 0부터 시작, 1부터 시작해서 인덱스 +=2 만큼 퐁당퐁당 더해주어서 최댓값을 리턴하는 식으로 했는데 6점 받고 다시 생각해 보았습니다 ... ㅎㅎ
그래서 메모이제이션을 생각했는데, 일단 최대한 많은 수를 선택하는게 이득이고(스티커 안 값이 모두 자연수이므로) 그리고 인덱스를 옮기면서 더 할때 이때까지 나온 제일 최댓값을 가지고 더해주면 된다고 생각했습니다. 
하지만, 단순히 인덱스를 옮길떄 +2 씩 옮겨주면 입력 배열이 [1,100,1,1,100] 의 배열을 처리하지 못했습니다. 
따라서 인덱스를 옮길때는 +2, +3 까지 해주어 메모이제이션을 수행해주었습니다 ..

그럼에도,, 6점이길래 영후의 피알을 훔쳐보았습니다 ~
입력 배열의 첫번째 요소를 선택하면 마지막 요소를 선택할 수 없게 됩니다. 그럼 마지막 요소가 포함된 배열을 만들어주기 위해선 첫번째 요소가 없어야 합니다. 따라서 이렇게 두개의 배열을 만들어 주고 위의 메모이제이션 과정을 2번 수행해주어 최댓값을 리턴하였습니다. 

## 🧐 참고 사항
후 피알 훔쳐본 박서현 ~  

## 📄 Reference
.
