### PR TITLE
PGMS_241018_단속카메라

### DIFF
--- a/hoo/october/week3/PGMS_241018_단속카메라.java
+++ b/hoo/october/week3/PGMS_241018_단속카메라.java
@@ -1,0 +1,38 @@
+package october.week3;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+public class PGMS_241018_단속카메라 {
+
+    public int solution(int[][] routes) {
+        int answer = findSpot(routes);
+
+        return answer;
+    }
+
+    int findSpot(int[][] routes) {
+        Arrays.sort(routes, new Comparator<int[]>() {   // 나간 지점 오름차순, 같을 경우 진입 지점 오름차순 정렬
+            @Override
+            public int compare(int[] i1, int[] i2) {
+                if (i1[1] == i2[1]) return i1[0] - i2[0];
+
+                return i1[1] - i2[1];
+            }
+        });
+
+        int spot = routes[0][1];    // 첫 지점은 첫 차의 나가는 지점으로 두고 시작
+        int spotCount = 1;
+        for (int i = 1; i < routes.length; i++) {
+            if (spot >= routes[i][0]) {  // 이전에 카메라를 설치한 곳이 이번 차의 진입 지점에 걸친다면
+                continue;
+            } else {    // 이번 차의 진입 지점에 걸치지 않는다면
+                spot = routes[i][1];
+                spotCount++;
+            }
+        }
+
+        return spotCount;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #136 

## 📝 문제 풀이 전략 및 실제 풀이 방법
차량들을 일렬로 나열한 상황을 머릿속으로 그려봤습니다. 그때 범위가 겹치는 차들 중 가장 오른쪽에 있는 좌표에만 카메라를 설치하면 된다고 판단하여
1. 나가는 지점 기준 오름차순 정렬
2. 1번이 같을 경우 진입 지점 기준 오름차순 정렬
을 해준 후, 반복문을 수행하며 범위가 겹치지 않는 경우 카메라의 좌표를 갱신하고 카메라의 개수 값을 +1씩 해주며 최소 카메라 개수를 구해주었습니다.

## 🧐 참고 사항


## 📄 Reference
