### PR TITLE
PGMS_241021_숫자카드나누기

### DIFF
--- a/hoo/october/week4/PGMS_241021_숫자카드나누기.java
+++ b/hoo/october/week4/PGMS_241021_숫자카드나누기.java
@@ -7,64 +7,51 @@ public class PGMS_241021_숫자카드나누기 {
 
     public int solution(int[] arrayA, int[] arrayB) {
         int answer = findAnswer(arrayA, arrayB);
-
         return answer;
     }
 
     int findAnswer(int[] arrayA, int[] arrayB) {
-        Arrays.sort(arrayA);    // 철수, 영희가 가진 카드를 우선 오름차순으로 정렬
-        Arrays.sort(arrayB);
+        int gcdA = findGCD(arrayA);  // arrayA와 arrayB의 GCD를 각각 계산
+        int gcdB = findGCD(arrayB);
 
-        int answer = 0;
-        answer = Math.max(answer, calcMaxNumber(arrayA, arrayB));
-        answer = Math.max(answer, calcMaxNumber(arrayB, arrayA));
+        int answer = 0;  // arrayA의 GCD로 arrayB의 숫자를 나눌 수 있는지 확인
+        if (isValidDivisor(gcdA, arrayB)) {
+            answer = Math.max(answer, gcdA);
+        }
 
-        return answer;
-    }
-
-    int calcMaxNumber(int[] firstArray, int[] secondArray) {    // firstArray: 모든 숫자를 나눌 수 있는 지 판단할 배열, secondArray: 모든 숫자를 나눌 수 없는 지 판단할 배열
-        PriorityQueue<Integer> divisorPq = makeDivisorPq(firstArray);  // firstArray의 첫 번째 숫자의 약수를 저장할 pq
-
-        int answer = 0;
-        boolean isPossible;
-        int divisor;
-        while (!divisorPq.isEmpty()) {  // 구한 약수들에 대해 수행
-            isPossible = true;
-            divisor = divisorPq.poll();
-            for (int i = 1; i < firstArray.length; i++) {   // 모든 숫자를 나눌 수 있는 지 판단
-                if (firstArray[i] % divisor != 0) {
-                    isPossible = false;
-                    break;
-                }
-            }
-            if (!isPossible) continue;  // 조건에 맞는 숫자가 아니라면 다음 약수로
-
-            for (int i = 0; i < secondArray.length; i++) {  // 모든 숫자가 나누어 떨어지지 않는 지 판단
-                if (secondArray[i] % divisor == 0) {
-                    isPossible = false;
-                    break;
-                }
-            }
-            if (!isPossible) continue;  // 조건에 맞는 숫자가 아니라면 다음 약수로
-            answer = divisor;   // 조건에 맞는 숫자라면 그 숫자로 갱신
+        if (isValidDivisor(gcdB, arrayA)) {  // arrayB의 GCD로 arrayA의 숫자를 나눌 수 있는지 확인
+            answer = Math.max(answer, gcdB);
         }
 
         return answer;
     }
 
-    PriorityQueue<Integer> makeDivisorPq(int[] array) {
-        PriorityQueue<Integer> divisorPq = new PriorityQueue<>();  // firstArray의 첫 번째 숫자의 약수를 저장할 pq
-        for (int i = 1; i <= Math.sqrt(array[0]); i++) {  // 약수 구하는 반복문
-            if (array[0] % i == 0) {
-                if (i == Math.sqrt(array[0])) divisorPq.offer(i);
-                else {
-                    divisorPq.offer(i);
-                    divisorPq.offer(array[0] / i);
-                }
+    int findGCD(int[] array) {  // 배열의 최대 공약수(GCD) 구하는 함수
+        int gcd = array[0];
+        for (int i = 1; i < array.length; i++) {
+            gcd = gcd(gcd, array[i]);
+            if (gcd == 1) break;  // GCD가 1이면 더 이상 계산할 필요 없음
+        }
+        return gcd;
+    }
+
+    int gcd(int a, int b) {  // 두 숫자의 최대 공약수(GCD) 계산
+        while (b != 0) {
+            int temp = b;
+            b = a % b;
+            a = temp;
+        }
+        return a;
+    }
+
+    boolean isValidDivisor(int gcd, int[] array) {  // 특정 GCD로 다른 배열의 숫자를 나눌 수 없는지 확인
+        for (int num : array) {
+            if (num % gcd == 0) {
+                return false;  // 하나라도 나누어 떨어지면 false
             }
         }
-
-        return divisorPq;
+        return true;
     }
+
 
 }

--- a/hoo/october/week4/PGMS_241021_숫자카드나누기.java
+++ b/hoo/october/week4/PGMS_241021_숫자카드나누기.java
@@ -1,0 +1,70 @@
+package october.week4;
+
+import java.util.Arrays;
+import java.util.PriorityQueue;
+
+public class PGMS_241021_숫자카드나누기 {
+
+    public int solution(int[] arrayA, int[] arrayB) {
+        int answer = findAnswer(arrayA, arrayB);
+
+        return answer;
+    }
+
+    int findAnswer(int[] arrayA, int[] arrayB) {
+        Arrays.sort(arrayA);    // 철수, 영희가 가진 카드를 우선 오름차순으로 정렬
+        Arrays.sort(arrayB);
+
+        int answer = 0;
+        answer = Math.max(answer, calcMaxNumber(arrayA, arrayB));
+        answer = Math.max(answer, calcMaxNumber(arrayB, arrayA));
+
+        return answer;
+    }
+
+    int calcMaxNumber(int[] firstArray, int[] secondArray) {    // firstArray: 모든 숫자를 나눌 수 있는 지 판단할 배열, secondArray: 모든 숫자를 나눌 수 없는 지 판단할 배열
+        PriorityQueue<Integer> divisorPq = makeDivisorPq(firstArray);  // firstArray의 첫 번째 숫자의 약수를 저장할 pq
+
+        int answer = 0;
+        boolean isPossible;
+        int divisor;
+        while (!divisorPq.isEmpty()) {  // 구한 약수들에 대해 수행
+            isPossible = true;
+            divisor = divisorPq.poll();
+            for (int i = 1; i < firstArray.length; i++) {   // 모든 숫자를 나눌 수 있는 지 판단
+                if (firstArray[i] % divisor != 0) {
+                    isPossible = false;
+                    break;
+                }
+            }
+            if (!isPossible) continue;  // 조건에 맞는 숫자가 아니라면 다음 약수로
+
+            for (int i = 0; i < secondArray.length; i++) {  // 모든 숫자가 나누어 떨어지지 않는 지 판단
+                if (secondArray[i] % divisor == 0) {
+                    isPossible = false;
+                    break;
+                }
+            }
+            if (!isPossible) continue;  // 조건에 맞는 숫자가 아니라면 다음 약수로
+            answer = divisor;   // 조건에 맞는 숫자라면 그 숫자로 갱신
+        }
+
+        return answer;
+    }
+
+    PriorityQueue<Integer> makeDivisorPq(int[] array) {
+        PriorityQueue<Integer> divisorPq = new PriorityQueue<>();  // firstArray의 첫 번째 숫자의 약수를 저장할 pq
+        for (int i = 1; i <= Math.sqrt(array[0]); i++) {  // 약수 구하는 반복문
+            if (array[0] % i == 0) {
+                if (i == Math.sqrt(array[0])) divisorPq.offer(i);
+                else {
+                    divisorPq.offer(i);
+                    divisorPq.offer(array[0] / i);
+                }
+            }
+        }
+
+        return divisorPq;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #141 

## 📝 문제 풀이 전략 및 실제 풀이 방법
조건을 보면 한 배열을 기준으로 잡고 1번 조건의 달성을 위해, 그리디하게 해당 배열의 가장 작은 수의 약수들을 이용하면 되겠다는 생각을 했습니다. 그와 동시에 2번 조건의 경우는 1번 조건을 만족했을 때 그 숫자로 따져보면 되는 것이라고 판단했습니다. 그 후에 따져본 조건이 각자에게 주어진 숫자 카드의 수가 50만이라는 점이었고, 시간 관리가 문제 풀이의 관건이라고 판단했습니다.

시간을 고려해 알고리즘을 구상해보았고, 처음 고안한 방법은 각자에게 주어진 숫자 카드를 오름차순으로 정렬하는 데에 O(NlogN)이 소요, 1번 조건의 판별을 위해 약수를 구하는 경우에 O(1억^(1/2))이 소요, 1번 조건과 2번 조건을 따져보는 데에 2*O(50만)이 소요되므로 전체 시간복잡도는 O(2 * 50만 * 1억^(1/2))이 됩니다. 그럼 50억인데 이대로 제출헀더니 통과가 됐네요.. 왜 통과가 되는 걸까요? 잘 모르겠습니다. 찝찝해서 더 효율적인 풀이를 고안해봤습니다.

다음으로 고안한 방법은 1번 조건의 충족을 위해 한 배열의 최대 공약수를 구하고, 2번 조건의 충족을 위해 그 수로 다른 배열을 나눌 수 없는 지 판단하는 것입니다. 최대공약수를 구하는 로직의 시간 복잡도는 O(50만log(1억))이며, 다른 배열을 나눌 수 없는 지 판단하는 로직의 시간 복잡도는 O(50만)으로, 최종 시간 복잡도는 O(50만log(1억))으로 이는 약 1300만의 값입니다.

이런 식으로 시간 복잡도를 고려해 설계하는 것에 따라 오버헤드가 정말 천지 차이가 날 수도 있음을 알게 된 문제였습니다. 첫 번째 코드는 첫 번째 커밋에 있으니 참고하시고자 한다면 참고하시면 되겠습니다.

## 🧐 참고 사항
<img width="531" alt="image" src="https://github.com/user-attachments/assets/19cb01e1-c525-4d26-bb17-06e7dcaaa6da">


## 📄 Reference
