### PR TITLE
PGMS_241023_디펜스 게임

### DIFF
--- a/hoo/october/week4/PGMS_241023_디펜스게임.java
+++ b/hoo/october/week4/PGMS_241023_디펜스게임.java
@@ -1,0 +1,33 @@
+package october.week4;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+public class PGMS_241023_디펜스게임 {
+
+    public int solution(int n, int k, int[] enemy) {
+        int answer = doDefenceGame(n, k, enemy);
+
+        return answer;
+    }
+
+    int doDefenceGame(int n, int k, int[] enemy) { // n: 최초 병사 수, k: 무적권 횟수, enemy[i]: 매 라운드의 적
+        PriorityQueue<Integer> kPq = new PriorityQueue<>(Comparator.reverseOrder());  // 무적권을 어느 라운드에 사용할 지 모름. 그러므로 모든 라운드를 무적권을 사용할 후보로 두기 위해 pq에 저장, 적 수 많은 곳에 무적권 쓰기 위해 내림차순으로 정렬함.
+        int answer = enemy.length;  // 모든 라운드를 방어해낼 경우를 대비해 answer의 초기값은 적의 수만큼
+        for (int i = 0; i < enemy.length; i++) {    // 모든 적에 대해
+            kPq.offer(enemy[i]); // 무적권 사용할 후보로 두기 위해 pq에 넣어두기
+            if (n < enemy[i]) {   // 병사 수 부족한 경우
+                if (k == 0) {   // 근데 무적권도 없음
+                    answer = i;
+                    break;
+                }
+                n += kPq.poll(); // 무적권을 사용할 라운드의 적 수만큼 병사 수 충족
+                k--;    // 무적권 사용
+            }
+            n -= enemy[i];  // 병사 수가 충분할 때는 병사 사용하여 막음
+        }
+
+        return answer;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #148 

## 📝 문제 풀이 전략 및 실제 풀이 방법
처음에는 스택을 떠올렸습니다. 하지만 매 라운드를 지나가며 최댓값에 무적권을 사용할 수 있다는 보장이 없다는 것을 알게 된 후에 다른 방법을 고안하게 되었습니다.

그렇게 떠올린 것이 '무적권을 사용할 라운드를 찾기 보다는, 무적권을 사용하는 것을 병사 수를 추가로 얻는 것과 같이 생각하면 된다' 는 것이었습니다. 하지만 어떤 라운드에서 무적권을 사용할 지는 여전히 고려되지 않았습니다. 한참을 생각해보니 일상생활에서 쇼핑할 때 쿠폰을 어떤 품목에 적용하는 게 가장 효율적인가?와 상황이 같다는 것을 알게 되었습니다. 

장바구니에 매 상품을 추가할 때마다(이 문제에서는 매 라운드) 가장 이득인 상품(이 문제에서는 가장 적이 많은 라운드의 적 수)을 우선순위로 두고 쇼핑을 하는 것과 같다는 생각이 들었습니다. 그래서 쇼핑을 끝낼 때까지(모든 적들에 대해) 예산이 허락하는 만큼(주어진 n만큼), 쿠폰을 적용해가며(무적권을 사용해) 예산과 쿠폰을 모두 사용할 때까지(n이 충분하고 k가 0이 되기 전까지) 매 상품마다 쿠폰을 적용할 상품의 후보군(가장 비싼 품목이 우선순위를 가지게, 이 문제에서는 가장 적이 많은 라운드의 적 수)을 관리하고 예산 부족 시마다 우선순위 상품에 쿠폰을 적용하며 쇼핑한다는 느낌으로 로직을 작성해봤습니다.
그리하여 모든 적에 대해 for문을 통해 순회하며
  1. 각 적을 무적권을 적용할 후보군으로 두기 위해 내림차순의 정수형 PriorityQueue에 넣어주었습니다.
  2. 그 후 현재 라운드에서 n이 부족한 지 판단, 부족하지 않다면 병사를 이용하여 라운드를 넘깁니다. 
  3. n이 부족하다면 잔여 무적권이 있는 지를 판단합니다. 
    1. 잔여 무적권이 없다면 게임이 종료됩니다. 이때 answer의 값을 해당 라운드로 갱신해줍니다.
    2. 잔여 무적권이 있다면 해당 라운드를 넘기기 위해 무적권의 후보군 중 가장 높은 적의 수를 가진 라운드에 무적권을 적용, 사용한 라운드의 적 수만큼 n을 채워주고 무적권 횟수를 1만큼 차감합니다.

이런 로직을 통해 반복문을 모두 수행, 도중에 게임이 종료되지 않는다면 주어진 적의 수만큼을 정답으로 반환해주어 문제를 해결했습니다.

## 🧐 참고 사항
PriorityQueue를 떠올리기 전 Map과 각 라운드에서 max값을 이용해서 로직을 작성해볼까 했지만, 무적권을 사용했을 때 max값 갱신이 어떻게 이루어져야할 지가 완벽히 떠오르지가 않았습니다. map과 max값을 사용하면 시간복잡도가 더 줄어들지가 궁금하긴 합니다.

## 📄 Reference
