### PR TITLE
PGMS_241024_올림픽

### DIFF
--- a/hyun/10_october/BOJ_241024_올림픽.java
+++ b/hyun/10_october/BOJ_241024_올림픽.java
@@ -1,0 +1,68 @@
+package sort;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_241024_올림픽 {
+    static int N,K;
+    static ArrayList<Node> input = new ArrayList<>();
+    static class Node{
+        int num;
+        int a,b,c;
+        Node(int num, int a, int b, int c){
+            this.num = num;
+            this.a = a;
+            this.b = b;
+            this.c = c;
+        }
+    }
+
+    public static boolean isSame(Node n1, Node n2){
+        if(n1.a == n2.a && n1.b == n2.b && n1.c == n2.c) return true;
+        return false;
+    }
+
+    public static int simulation() {
+        // 정렬
+        Collections.sort(input, new Comparator<Node>() {
+            @Override
+            public int compare(Node o1, Node o2) {
+                if (o1.a == o2.a && o1.b == o2.b) return o2.c - o1.c;
+                else if (o1.a == o2.a) return o2.b - o1.b;
+                return o2.a - o1.a;
+            }
+        });
+
+        if(K == input.get(0).num) return 1;
+
+        int rank = 1;
+
+        for(int i=1; i<input.size();i++){
+            if(!isSame(input.get(i-1), input.get(i))){
+                rank = i+1;
+            }
+
+            if(K == input.get(i).num) break;
+        }
+
+        return rank;
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int num = Integer.parseInt(st.nextToken());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            input.add(new Node(num,a,b,c));
+        }
+
+        System.out.println(simulation());
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#151 


## 📝 문제 풀이 전략 및 실제 풀이 방법
1. 금,은,동 갯수가 많은 순으로 정렬을 해줍니다.
2. 맨 처음 나라가 K 라면 바로 랭킹 1을 리턴해주었고, 정렬된 배열 첫번째 인덱스부터 순회할건데 여기선 등수를 반복문의 인덱스 값을 이용하였습니다. 이때 동점자 처리를 위해 rank 라는 변수를 따로 두어 현재의 국가가 전의 국가와 같다면 -> 해당 국가는 rank 등수 그대로 들고 가고 / 같지 않다면 -> rank 를 현재 반복문의 인덱스 + 1 로 가져갑니다.  그다음, 문제에서 요구하는 K 국가가 맞는지 확인한 후, 맞다면 rank 를 리턴해줍니다 !

## 🧐 참고 사항
.

## 📄 Reference
.
