### PR TITLE
PGMS_241030_경주로 건설

### DIFF
--- a/hoo/october/week5/PGMS_241030_경주로건설.java
+++ b/hoo/october/week5/PGMS_241030_경주로건설.java
@@ -1,0 +1,69 @@
+import java.util.*;
+
+class Solution {
+
+    class Road {
+        int row;
+        int col;
+        int dir;
+        int length;  // 도로 길이
+        int turn;   // 도로 건설에 쓰인 코너 개수
+
+        public Road(int row, int col, int dir, int length, int turn) {
+            this.row = row;
+            this.col = col;
+            this.dir = dir;
+            this.length = length;
+            this.turn = turn;
+        }
+    }
+
+    int[] dirRow = new int[] {-1, 0, 1, 0}; // 상 우 하 좌
+    int[] dirCol = new int[] {0, 1, 0, -1};
+    int minCost;
+
+    public int solution(int[][] board) {
+        minCost = Integer.MAX_VALUE;
+        for (int d = 1; d <= 2; d++) {  // 시작점에서 1. 우 / 2. 하로 이동한 것을 가정하고 시작
+            if (board[dirRow[d]][dirCol[d]] == 1) continue; // 그 와중에 바로 옆칸이 벽이면 해당 경로는 탐색 안함
+            int[][] isVisited = new int[board.length][board[0].length]; // 이미 더 적은 비용으로 연결한 도로가 있는 지 여부 판별하기 위해 boolean[][]이 아닌 int[][]로 선언
+            for (int i = 0; i < isVisited.length; i++) Arrays.fill(isVisited[i], Integer.MAX_VALUE);
+            isVisited[0][0] = 0;
+            isVisited[dirRow[d]][dirCol[d]] = 100;
+            makeRoad(board, new Road(dirRow[d], dirCol[d], d, 1, 0), isVisited);
+        }
+
+        return minCost;
+    }
+
+    void makeRoad(int[][] board, Road now, int[][] isVisited) {
+        if (now.row == board.length-1 && now.col == board[0].length-1) {  // 기저, 도로를 도착점까지 만든 경우
+            minCost = Math.min(minCost, now.length*100 + now.turn*500);
+            return;
+        }
+
+        int nextRow, nextCol, nextCost;
+        Road next;
+        for (int d = 0; d < 4; d++) {
+            nextRow = now.row + dirRow[d];
+            nextCol = now.col + dirCol[d];
+            if (isOuted(board, nextRow, nextCol) || board[nextRow][nextCol] == 1) continue; // 범위 밖이거나 벽으로 막힌 곳, 이미 도로를 놓은 곳이면 건너 뜀
+            next = new Road(nextRow, nextCol, d, now.length+1, (now.dir==d)?now.turn:now.turn+1);
+            nextCost = calcCost(next);
+            if (isVisited[nextRow][nextCol] < nextCost) continue; // 이미 더 적은 비용으로 연결한 도로가 있으면 건너 뜀
+
+            isVisited[nextRow][nextCol] = nextCost;
+            makeRoad(board, next, isVisited);
+        }
+    }
+
+    boolean isOuted(int[][] board, int row, int col) {
+        if ((0 <= row && row < board.length) && (0 <= col && col < board[0].length)) return false;
+        return true;
+    }
+
+    int calcCost(Road road) {
+        return road.length*100 + road.turn*500;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #160 

## 📝 문제 풀이 전략 및 실제 풀이 방법
간단하게 백트래킹으로 접근하고자 했고, 그렇게 했습니다. 하지만 시간초과가 나게 되었고, 방문을 처리하는 isVisited 변수를 boolean[][]에서 int[][]로 변경, 각 칸까지 도로를 건설하는 데 드는 최소 비용을 저장해주었습니다. 이 변수를 이용하여 각 칸까지 드는 비용이 더 작을 경우에만 탐색을 계속하게 로직을 수정하여 해결했습니다.
isVisited를 boolean[][]으로 두었을 때는 매 루트마다 각 칸에서 4방향의 선택을 해야하므로 4^(n*n)만큼의 시간복잡도가 들지만, int[][]로 두어 필요없는 경로는 탐색하지 않는다면 각 칸에서 한 번씩만 4방향에 대한 선택을 하면 되는 식의 로직으로 바뀌므로 (n^2) * 4의 시간복잡도를 가지게 됩니다.(뇌피셜)
그래서 앞으로 문제풀이 시에 비용을 따지는 문제가 나온다면 boolean[][] 형태의 방문 배열을 두는 것보다는 int[][] 형태로 매 비용을 체크해주는 것이 히든 테스트 케이스의 시간 초과를 방지할 수 있는 등 전략적으로 좋을 것이라는 생각이 든 문제였습니다.

## 🧐 참고 사항


## 📄 Reference
