### PR TITLE
PGMS_241030_경주로건설 & BOJ_241031_용액

### DIFF
--- a/hyun/10_october/BOJ_241031_용액.java
+++ b/hyun/10_october/BOJ_241031_용액.java
@@ -1,0 +1,46 @@
+package two_pointer;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_241031_용액 {
+    static int N;
+    static long[] input;
+    static long[] answer;
+
+    public static void simulation(){
+        int left = 0;
+        int right = N-1;
+
+        while(true){
+            long sum = input[left] + input[right];
+
+            if(sum < 0) left++;
+            else if(sum > 0) right--;
+
+            if(left < N && right >= 0 && left < right){
+                if(Math.abs(answer[1] + answer[0]) > Math.abs(input[right] + input[left]))
+                    answer = new long[]{input[left], input[right]};
+                if(sum == 0) break;
+            }
+            else break;
+        }
+
+        System.out.println(answer[0] + " " + answer[1]);
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        input = new long[N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            input[i] = Long.parseLong(st.nextToken());
+        }
+
+        answer = new long[]{input[0], input[N-1]};
+        simulation();
+    }
+}

--- a/hyun/10_october/PGMS_241030_경주로건설.java
+++ b/hyun/10_october/PGMS_241030_경주로건설.java
@@ -28,28 +28,23 @@ public class PGMS_241030_경주로건설 {
 
     public int simulation(){
         Queue<Node> q = new ArrayDeque<>();
-        int[][][] visited = new int[N][N][4];
+        int[][] visited = new int[N][N];
         for(int i=0; i<N; i++)
             for(int j=0; j<N; j++)
-                for(int k=0; k<4; k++)
-                    visited[i][j][k] = Integer.MAX_VALUE;
-
-        visited[0][0][0] = 0;
-        visited[0][0][1] = 0;
-        visited[0][0][2] = 0;
-        visited[0][0][3] = 0;
+                visited[i][j] = Integer.MAX_VALUE;
 
         if(map[0][1] == 0) {
             q.add(new Node(0,1,3));
-            visited[0][1][3] = 100;
+            visited[0][1] = 100;
         }
         if(map[1][0] == 0) {
             q.add(new Node(1,0,1));
-            visited[1][0][1] = 100;
+            visited[1][0] = 100;
         }
 
         while(!q.isEmpty()){
             Node cur = q.poll();
+
 
             for(int k=0; k<4; k++){
                 int nx = cur.x + dx[k];
@@ -57,21 +52,19 @@ public class PGMS_241030_경주로건설 {
 
                 if(nx < 0 || nx >= N || ny <0 || ny >= N || map[nx][ny] == 1) continue;
 
-                int cost = visited[cur.x][cur.y][cur.d];
-                if(calCost(cur.d, k)) cost += 100;
+                int cost = visited[cur.x][cur.y];
+                boolean isFlag = false;
+                if(calCost(cur.d, k)) {cost += 100; isFlag = true;}
                 else cost += 600;
 
-                if(visited[nx][ny][k] > cost){
+                if(visited[nx][ny] >= cost){
                     q.add(new Node(nx,ny,k));
-                    visited[nx][ny][k] = cost;
+                    visited[nx][ny] = cost;
                 }
-
             }
         }
 
-        int answer = visited[N-1][N-1][0];
-        for(int i=1; i<4; i++) answer = Math.min(answer, visited[N-1][N-1][i]);
-        return answer;
+        return visited[N-1][N-1];
 
     }
     public int solution(int[][] board) {

--- a/hyun/10_october/PGMS_241030_경주로건설.java
+++ b/hyun/10_october/PGMS_241030_경주로건설.java
@@ -1,0 +1,83 @@
+package bfs;
+
+import java.util.*;
+
+public class PGMS_241030_경주로건설 {
+    int N;
+    int[][] map;
+    int[] dx = {-1,1,0,0};
+    int[] dy = {0,0,-1,1};
+
+    class Node{
+        int x,y,d;
+        Node(int x, int y, int d){
+            this.x = x;
+            this.y = y;
+            this.d = d;
+        }
+    }
+
+    public boolean calCost(int d1, int d2){
+        if(d1 == 0 && (d2 == 2 || d2 == 3)) return false;
+        else if(d1 == 1 && (d2 == 2 || d2 == 3)) return false;
+        else if(d1 == 2 && (d2 == 0 || d2 == 1)) return false;
+        else if(d1 == 3 && (d2 == 0 || d2 == 1)) return false;
+
+        return true;
+    }
+
+    public int simulation(){
+        Queue<Node> q = new ArrayDeque<>();
+        int[][][] visited = new int[N][N][4];
+        for(int i=0; i<N; i++)
+            for(int j=0; j<N; j++)
+                for(int k=0; k<4; k++)
+                    visited[i][j][k] = Integer.MAX_VALUE;
+
+        visited[0][0][0] = 0;
+        visited[0][0][1] = 0;
+        visited[0][0][2] = 0;
+        visited[0][0][3] = 0;
+
+        if(map[0][1] == 0) {
+            q.add(new Node(0,1,3));
+            visited[0][1][3] = 100;
+        }
+        if(map[1][0] == 0) {
+            q.add(new Node(1,0,1));
+            visited[1][0][1] = 100;
+        }
+
+        while(!q.isEmpty()){
+            Node cur = q.poll();
+
+            for(int k=0; k<4; k++){
+                int nx = cur.x + dx[k];
+                int ny = cur.y + dy[k];
+
+                if(nx < 0 || nx >= N || ny <0 || ny >= N || map[nx][ny] == 1) continue;
+
+                int cost = visited[cur.x][cur.y][cur.d];
+                if(calCost(cur.d, k)) cost += 100;
+                else cost += 600;
+
+                if(visited[nx][ny][k] > cost){
+                    q.add(new Node(nx,ny,k));
+                    visited[nx][ny][k] = cost;
+                }
+
+            }
+        }
+
+        int answer = visited[N-1][N-1][0];
+        for(int i=1; i<4; i++) answer = Math.min(answer, visited[N-1][N-1][i]);
+        return answer;
+
+    }
+    public int solution(int[][] board) {
+        N = board.length;
+        map = board;
+
+        return simulation();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#160 


## 📝 문제 풀이 전략 및 실제 풀이 방법
## 1. 경주로 건설
BFS 풀이에다가 방문배열은 각 위치까지의 최소 비용을 저장하는 식으로 구현했습니다.

### 68점
방문배열을 2차원으로 해주었습니다. 이떄, 한 위치까지 여러 방향으로 접근하였더라도 비용은 똑같을 수 있으므로 다음 좌표를 봐줄때 다음좌표까지의 비용이 다음 방문 배열의 칸보다 작거나 같으면 큐에 넣어주는 식으로 구현하였습니다. 하지만 68 점 ! ,, 

### 정답
한 지점까지 여러 방향으로 오는 경우를 방문배열을 3차원으로 하면 깔끔하겠다고 생각했습니다. 3차원으로 바꿨더니 정답을 받게 되었는데요 .. 하지만, 저는 위의 풀이와는 차이가 없다고 생각하는게 위의 풀이도 하나의 지점까지 같은 비용으로 되더라도 다 다른 방향으로 올 수 있어서 조건문을 같다는 표시를 추가해주면 정답 풀이랑 똑같은 로직이 되지 않을까 ..하는 생각에 머물러 있습니다.. 

-----------------------
아래 링크에서 왜 2차원말고 3차원 배열을 써야하는지 알게되었습니다 !

=========================================================================
## 2. 용액
투포인터로 풀었습니다. 입력 배열은 이미 정렬된 상태이니 배열의 처음과 끝 인덱스를 가르키는 left, right 변수를 두어 조정해주었습니다. 조정하는 기준은 left, right 가 가르키는 배열의 합이 0보다 작으면 left 를 늘려주고 0 보다 크면 right 를 줄여주면서 left와 right 가 범위 안에 있으면서 서로 엇갈리지 않는다면 0에 가까운 정답값으로 갱신해나가고 그렇지 않거나 합이 0이라면 탐색을 종료해주었습니다. 이때 유의할 점은 배열의 입력값의 최댓값이 10^9 이므로 합을 구할때 안전하게 ~ 변수를 long 으로 지정해주었는데 ..! int 의 최대범위가 2X10^9 조금 넘어가서 합을 int 로 해도 문제 없었습니다.

## 🧐 참고 사항
아래는 경주로 건설에서 제가 왜 68점을 받게되었는지에 대한 이유를 알게 된 글입니다람쥐드래곤 ~
[왜 3차원 배열을 써야하는지](https://school.programmers.co.kr/questions/30355)

## 📄 Reference
.
