### PR TITLE
BOJ_241031_용액

### DIFF
--- a/hoo/october/week5/Main_2467_용액.java
+++ b/hoo/october/week5/Main_2467_용액.java
@@ -1,0 +1,45 @@
+package october.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_2467_용액 {
+
+    static int N;
+    static int[] liquids;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        findAlmostZero();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        liquids = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) liquids[i] = Integer.parseInt(st.nextToken());
+    }
+
+    static void findAlmostZero() {
+        int answerSum = Integer.MAX_VALUE;
+        int[] answer = new int[2];
+
+        int left = 0;
+        int right = N-1;
+        int sum;
+        while (left < right) {
+            sum = liquids[left] + liquids[right];
+            if (Math.abs(0-answerSum) >= Math.abs(0-sum)) {
+                answerSum = sum;
+                answer = new int[] {liquids[left], liquids[right]};
+            }
+            if (sum > 0) right--;
+            else left++;
+        }
+        System.out.println(answer[0] + " " + answer[1]);
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #162 

## 📝 문제 풀이 전략 및 실제 풀이 방법
n 개수가 10만이므로 N^2 이하로 풀이해내야 합니다. 문제에서 용액을 오름차순 정렬하여 제공했고, 두 개의 합이 0에 가까운 것을 골라야하므로 투 포인터를 떠올렸습니다.
left를 맨 앞, right를 맨 뒤에서 출발시켜 두 수의 합이 0보다 작거나 같다면 left를 ++, 0보다 크다면 right를 --해주어 해결했습니다.

## 🧐 참고 사항


## 📄 Reference
