### PR TITLE
BOJ_241105_주식

### DIFF
--- a/hyun/11_november/BOJ_241105_주식.java
+++ b/hyun/11_november/BOJ_241105_주식.java
@@ -1,0 +1,39 @@
+package stack;
+
+import java.io.*;
+import java.util.*;
+public class BOJ_241105_주식 {
+    static int T,N;
+    static int[] input;
+
+    public static long simulation(){
+        long answer = 0;
+        int maxValue = input[N-1];
+
+        for (int i = N-2; i >= 0; i--) {
+            if(input[i] < maxValue) answer += (maxValue - input[i]);
+            else if(input[i] > maxValue) maxValue = input[i];
+        }
+
+        return answer;
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        T = Integer.parseInt(br.readLine());
+        for (int tc = 0; tc < T; tc++) {
+            N = Integer.parseInt(br.readLine());
+            st = new StringTokenizer(br.readLine());
+            input = new int[N];
+            for (int i = 0; i < N; i++) {
+                input[i] = Integer.parseInt(st.nextToken());
+            }
+
+            sb.append(simulation()).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#169 


## 📝 문제 풀이 전략 및 실제 풀이 방법
입력받은 배열 첫번째부터 순회하며 봐줬을때 현재 주식이 뒤에 나올 주식중 제일 큰 주식일때 팔아야 합니다. 하지만 현재 주식일때 뒤에 나올 주식 들 중 제일 큰 주식을 어떻게 찾을 수 있을까 하다가 2중 포문으로 했을시엔 시간초과가 날 가능성이 컸습니다. 따라서, 뒤에서 봐주자고 생각했습니다. 뒤에서 봐주면서 주식이 자기보다 작다면 그 주식은 사서 기준점 주식날 팔면 최대이익이 됩니다. 이렇게 하다가 자기보다 큰 주식이 나오면 해당 주식으로 기준점을 바꿔주면서 최대이익을 계산해주었습니다. 

## 🧐 참고 사항
.

## 📄 Reference
.
