### PR TITLE
BOJ_241107_미로탈출

### DIFF
--- a/hyun/11_november/BOJ_241107_미로탈출.java
+++ b/hyun/11_november/BOJ_241107_미로탈출.java
@@ -1,0 +1,88 @@
+package bfs;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_241107_미로탈출 {
+    static int N,M;
+    static int sx,sy,ex,ey;
+    static int[][] map;
+    static int[] dx = {-1,1,0,0};
+    static int[] dy = {0,0,-1,1};
+    static class Node{
+        int x,y,cnt;
+        Node(int x, int y,int cnt){
+            this.x = x;
+            this.y = y;
+            this.cnt = cnt;
+        }
+    }
+
+    public static void simulation(){
+        Queue<Node> q = new ArrayDeque<>();
+        int[][][] visited = new int[N][M][2];
+
+        if(map[sx][sy] == 1) {
+            q.add(new Node(sx,sy,1));
+            visited[sx][sy][1] = 1;
+        }else{
+            q.add(new Node(sx,sy,0));
+            visited[sx][sy][0] = 1;
+        }
+
+        while(!q.isEmpty()){
+            Node cur = q.poll();
+
+            if(cur.x == ex && cur.y == ey){
+                System.out.println(visited[ex][ey][cur.cnt] - 1);
+                return;
+            }
+
+            for (int k = 0; k < 4; k++) {
+                int nx = cur.x + dx[k];
+                int ny = cur.y + dy[k];
+
+                if(nx < 0 || nx >= N || ny < 0 || ny >= M) continue;
+                if(map[nx][ny] == 1){
+                    if(visited[nx][ny][1] == 0 && cur.cnt == 0){
+                        q.add(new Node(nx,ny,1));
+                        visited[nx][ny][1] = visited[cur.x][cur.y][cur.cnt] + 1;
+                    }
+                }
+                else{
+                    if(visited[nx][ny][cur.cnt] == 0){
+                        q.add(new Node(nx,ny,cur.cnt));
+                        visited[nx][ny][cur.cnt] = visited[cur.x][cur.y][cur.cnt] + 1;
+                    }
+                }
+            }
+        }
+
+        System.out.println(-1);
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        sx = Integer.parseInt(st.nextToken()) - 1;
+        sy = Integer.parseInt(st.nextToken()) - 1;
+
+        st = new StringTokenizer(br.readLine());
+        ex = Integer.parseInt(st.nextToken()) - 1;
+        ey = Integer.parseInt(st.nextToken()) - 1;
+
+        map = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        simulation();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#172 


## 📝 문제 풀이 전략 및 실제 풀이 방법
###BFS
지팡이는 한번 쓸 수 있으므로, 기본적인 BFS 를 수행할때 방문배열을 3차원으로 선언해주어 (x,y,z) 여기서 z값은 지팡이 쓴 유무를 구분해주었습니다. 

다음 좌표를 볼때,
1. 다음 좌표가 벽이면, 현재 지팡이는 쓰지 않은 상태이면 z값을 1 로 변경하여 방문 배열에 저장해줍니다.
2. 다음 좌표가 길이면, 현재 지팡이의 상태를 그대로 들고가면서 방문 배열에 저장해줍니다.

이떄, 방문 배열을 int 로 선언하고 시작값을 1로 구분하여 방문하지 않은 상태는 0으로 방문한 상태는 0이 아닌 상태로 구분지어주었습니당구

## 🧐 참고 사항
.

## 📄 Reference
.
