### PR TITLE
BOJ_241107_쉬운최단거리

### DIFF
--- a/hyun/11_november/BOJ_241107_쉬운최단거리.java
+++ b/hyun/11_november/BOJ_241107_쉬운최단거리.java
@@ -1,0 +1,78 @@
+package bfs;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_241107_쉬운최단거리 {
+    static int N,M;
+    static int ex,ey;
+    static int[][] input;
+    static int[][] map;
+    static int[] dx = {-1,1,0,0};
+    static int[] dy = {0,0,-1,1};
+    static StringBuilder sb = new StringBuilder();
+    static class Node{
+        int x,y;
+        Node(int x,int y){
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    public static void simulation(){
+        Queue<Node> q = new ArrayDeque<>();
+        boolean[][] visited = new boolean[N][M];
+
+        q.add(new Node(ex,ey));
+        visited[ex][ey] = true;
+
+        while(!q.isEmpty()){
+            Node cur = q.poll();
+
+            for(int k =0; k<4; k++){
+                int nx = cur.x + dx[k];
+                int ny = cur.y + dy[k];
+                if(nx<0 || nx >= N || ny < 0 || ny >= M || visited[nx][ny] || input[nx][ny] != 1) continue;
+
+                q.add(new Node(nx, ny));
+                visited[nx][ny] = true;
+                map[nx][ny] = map[cur.x][cur.y] + 1;
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                sb.append(map[i][j]).append(" ");
+            }
+            sb.append("\n");
+        }
+        System.out.println(sb);
+
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        input = new int[N][M];
+        map = new int[N][M];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                input[i][j] = Integer.parseInt(st.nextToken());
+                if(input[i][j] == 2){
+                    ex = i;
+                    ey = j;
+                    map[i][j] = 0;
+                }
+                else if(input[i][j] == 0) map[i][j] = 0;
+                else map[i][j] = -1;
+            }
+        }
+
+        simulation();
+    }
+}

--- a/hyun/11_november/BOJ_241107_쉬운최단거리.java
+++ b/hyun/11_november/BOJ_241107_쉬운최단거리.java
@@ -4,75 +4,78 @@ import java.io.*;
 import java.util.*;
 
 public class BOJ_241107_쉬운최단거리 {
-    static int N,M;
-    static int ex,ey;
-    static int[][] input;
-    static int[][] map;
-    static int[] dx = {-1,1,0,0};
-    static int[] dy = {0,0,-1,1};
-    static StringBuilder sb = new StringBuilder();
-    static class Node{
-        int x,y;
-        Node(int x,int y){
-            this.x = x;
-            this.y = y;
-        }
-    }
-
-    public static void simulation(){
-        Queue<Node> q = new ArrayDeque<>();
-        boolean[][] visited = new boolean[N][M];
-
-        q.add(new Node(ex,ey));
-        visited[ex][ey] = true;
-
-        while(!q.isEmpty()){
-            Node cur = q.poll();
-
-            for(int k =0; k<4; k++){
-                int nx = cur.x + dx[k];
-                int ny = cur.y + dy[k];
-                if(nx<0 || nx >= N || ny < 0 || ny >= M || visited[nx][ny] || input[nx][ny] != 1) continue;
-
-                q.add(new Node(nx, ny));
-                visited[nx][ny] = true;
-                map[nx][ny] = map[cur.x][cur.y] + 1;
-            }
-        }
-
-        for (int i = 0; i < N; i++) {
-            for (int j = 0; j < M; j++) {
-                sb.append(map[i][j]).append(" ");
-            }
-            sb.append("\n");
-        }
-        System.out.println(sb);
-
-    }
-    public static void main(String[] args) throws Exception{
+    public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-        StringTokenizer st = new StringTokenizer(br.readLine());
+        String[] splits = br.readLine().split(" ");
+        int n = Integer.parseInt(splits[0]);
+        int m = Integer.parseInt(splits[1]);
+        int[][] distance = new int[n][m];
+        boolean[][] cantGo = new boolean[n][m];
 
-        N = Integer.parseInt(st.nextToken());
-        M = Integer.parseInt(st.nextToken());
+        int[] yQ = new int[n * m];
+        int[] xQ = new int[n * m];
+        int front = 1;
+        int back = 0;
 
-        input = new int[N][M];
-        map = new int[N][M];
+        StringBuilder sb = new StringBuilder((n * m) << 3);
 
-        for (int i = 0; i < N; i++) {
-            st = new StringTokenizer(br.readLine());
-            for (int j = 0; j < M; j++) {
-                input[i][j] = Integer.parseInt(st.nextToken());
-                if(input[i][j] == 2){
-                    ex = i;
-                    ey = j;
-                    map[i][j] = 0;
+        for (int i = 0; i < n; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < m; j++) {
+                switch (line.charAt(j << 1)) {
+                    case '0':
+                        cantGo[i][j] = true;
+                        break;
+                    case '2':
+                        distance[i][j] = 1;
+                        yQ[0] = i;
+                        xQ[0] = j;
+                        break;
                 }
-                else if(input[i][j] == 0) map[i][j] = 0;
-                else map[i][j] = -1;
             }
         }
 
-        simulation();
+        while (front != back) {
+            int y = yQ[back];
+            int x = xQ[back++];
+
+            if (x > 0 && cantGo[y][x - 1] == false && distance[y][x - 1] == 0) {
+                yQ[front] = y;
+                xQ[front++] = x - 1;
+                distance[y][x - 1] = distance[y][x] + 1;
+            }
+
+            if (x < m - 1 && cantGo[y][x + 1] == false && distance[y][x + 1] == 0) {
+                yQ[front] = y;
+                xQ[front++] = x + 1;
+                distance[y][x + 1] = distance[y][x] + 1;
+            }
+
+            if (y > 0 && cantGo[y - 1][x] == false && distance[y - 1][x] == 0) {
+                yQ[front] = y - 1;
+                xQ[front++] = x;
+                distance[y - 1][x] = distance[y][x] + 1;
+            }
+
+            if (y < n - 1 && cantGo[y + 1][x] == false && distance[y + 1][x] == 0) {
+                yQ[front] = y + 1;
+                xQ[front++] = x;
+                distance[y + 1][x] = distance[y][x] + 1;
+            }
+        }
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (distance[i][j] != 0)
+                    sb.append(distance[i][j] - 1).append(' ');
+                else if (cantGo[i][j])
+                    sb.append("0 ");
+                else
+                    sb.append("-1 ");
+            }
+            sb.append('\n');
+        }
+
+        System.out.print(sb);
     }
 }

--- a/hyun/11_november/BOJ_241107_쉬운최단거리.java
+++ b/hyun/11_november/BOJ_241107_쉬운최단거리.java
@@ -21,10 +21,10 @@ public class BOJ_241107_쉬운최단거리 {
 
     public static void simulation(){
         Queue<Node> q = new ArrayDeque<>();
-        boolean[][] visited = new boolean[N][M];
+        //boolean[][] visited = new boolean[N][M];
 
         q.add(new Node(ex,ey));
-        visited[ex][ey] = true;
+        //visited[ex][ey] = true;
 
         while(!q.isEmpty()){
             Node cur = q.poll();
@@ -32,10 +32,9 @@ public class BOJ_241107_쉬운최단거리 {
             for(int k =0; k<4; k++){
                 int nx = cur.x + dx[k];
                 int ny = cur.y + dy[k];
-                if(nx<0 || nx >= N || ny < 0 || ny >= M || visited[nx][ny] || input[nx][ny] != 1) continue;
+                if(nx<0 || nx >= N || ny < 0 || ny >= M || map[nx][ny] != -1 || input[nx][ny] != 1) continue;
 
                 q.add(new Node(nx, ny));
-                visited[nx][ny] = true;
                 map[nx][ny] = map[cur.x][cur.y] + 1;
             }
         }

--- a/hyun/11_november/BOJ_241107_쉬운최단거리.java
+++ b/hyun/11_november/BOJ_241107_쉬운최단거리.java
@@ -4,78 +4,75 @@ import java.io.*;
 import java.util.*;
 
 public class BOJ_241107_쉬운최단거리 {
-    public static void main(String[] args) throws IOException {
+    static int N,M;
+    static int ex,ey;
+    static int[][] input;
+    static int[][] map;
+    static int[] dx = {-1,1,0,0};
+    static int[] dy = {0,0,-1,1};
+    static StringBuilder sb = new StringBuilder();
+    static class Node{
+        int x,y;
+        Node(int x,int y){
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    public static void simulation(){
+        Queue<Node> q = new ArrayDeque<>();
+        boolean[][] visited = new boolean[N][M];
+
+        q.add(new Node(ex,ey));
+        visited[ex][ey] = true;
+
+        while(!q.isEmpty()){
+            Node cur = q.poll();
+
+            for(int k =0; k<4; k++){
+                int nx = cur.x + dx[k];
+                int ny = cur.y + dy[k];
+                if(nx<0 || nx >= N || ny < 0 || ny >= M || visited[nx][ny] || input[nx][ny] != 1) continue;
+
+                q.add(new Node(nx, ny));
+                visited[nx][ny] = true;
+                map[nx][ny] = map[cur.x][cur.y] + 1;
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                sb.append(map[i][j]).append(" ");
+            }
+            sb.append("\n");
+        }
+        System.out.println(sb);
+
+    }
+    public static void main(String[] args) throws Exception{
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-        String[] splits = br.readLine().split(" ");
-        int n = Integer.parseInt(splits[0]);
-        int m = Integer.parseInt(splits[1]);
-        int[][] distance = new int[n][m];
-        boolean[][] cantGo = new boolean[n][m];
+        StringTokenizer st = new StringTokenizer(br.readLine());
 
-        int[] yQ = new int[n * m];
-        int[] xQ = new int[n * m];
-        int front = 1;
-        int back = 0;
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
 
-        StringBuilder sb = new StringBuilder((n * m) << 3);
+        input = new int[N][M];
+        map = new int[N][M];
 
-        for (int i = 0; i < n; i++) {
-            String line = br.readLine();
-            for (int j = 0; j < m; j++) {
-                switch (line.charAt(j << 1)) {
-                    case '0':
-                        cantGo[i][j] = true;
-                        break;
-                    case '2':
-                        distance[i][j] = 1;
-                        yQ[0] = i;
-                        xQ[0] = j;
-                        break;
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                input[i][j] = Integer.parseInt(st.nextToken());
+                if(input[i][j] == 2){
+                    ex = i;
+                    ey = j;
+                    map[i][j] = 0;
                 }
+                else if(input[i][j] == 0) map[i][j] = 0;
+                else map[i][j] = -1;
             }
         }
 
-        while (front != back) {
-            int y = yQ[back];
-            int x = xQ[back++];
-
-            if (x > 0 && cantGo[y][x - 1] == false && distance[y][x - 1] == 0) {
-                yQ[front] = y;
-                xQ[front++] = x - 1;
-                distance[y][x - 1] = distance[y][x] + 1;
-            }
-
-            if (x < m - 1 && cantGo[y][x + 1] == false && distance[y][x + 1] == 0) {
-                yQ[front] = y;
-                xQ[front++] = x + 1;
-                distance[y][x + 1] = distance[y][x] + 1;
-            }
-
-            if (y > 0 && cantGo[y - 1][x] == false && distance[y - 1][x] == 0) {
-                yQ[front] = y - 1;
-                xQ[front++] = x;
-                distance[y - 1][x] = distance[y][x] + 1;
-            }
-
-            if (y < n - 1 && cantGo[y + 1][x] == false && distance[y + 1][x] == 0) {
-                yQ[front] = y + 1;
-                xQ[front++] = x;
-                distance[y + 1][x] = distance[y][x] + 1;
-            }
-        }
-
-        for (int i = 0; i < n; i++) {
-            for (int j = 0; j < m; j++) {
-                if (distance[i][j] != 0)
-                    sb.append(distance[i][j] - 1).append(' ');
-                else if (cantGo[i][j])
-                    sb.append("0 ");
-                else
-                    sb.append("-1 ");
-            }
-            sb.append('\n');
-        }
-
-        System.out.print(sb);
+        simulation();
     }
 }


### PR DESCRIPTION
## 🔍 개요
#174 

## 📝 문제 풀이 전략 및 실제 풀이 방법
입력받을때 2인 좌표는 따로 저장하고, 입력받은 좌표값이 0이면 출력용 배열인 map 에 0으로 미리 채우고, 그 외엔 -1로 채웠습니다.  BFS는 2인 좌표인 곳 부터 수행해주었습니다. 

다른 사람 풀이를 보다가 시간이 엄청 짧은 사람의 코드를 보게 되었는데 BFS 수행할때 큐말고 1차원 배열써서 푼 것이 신기해서 코드 가져왔습니다. 커밋 내역에 파일명_240ms 로 된 것인데 궁금하면 한번 보셔욥
## 🧐 참고 사항
커밋 내역에서 BOJ_241107_쉬운최단거리, BOJ_241107_쉬운최단거리_524ms 는 같은 내용의 파일입니다 !!!
BOJ_241107_쉬운최단거리_524ms 로 시작된 파일이 2개가 있을텐데,, 한개는 BFS 수행할때 불리언 방문 배열을 또 선언해준것이고 다른 한개의 파일은 불리언 방문 배열을 없앤 것 입니다 !

## 📄 Reference
.
