### PR TITLE
PGMS_241108_순위

### DIFF
--- a/hyun/11_november/PGMS_241108_순위.java
+++ b/hyun/11_november/PGMS_241108_순위.java
@@ -1,0 +1,51 @@
+package dfs;
+
+import java.util.*;
+
+public class PGMS_241108_순위 {
+    int N;
+    ArrayList<Integer>[][] adj;
+    int answer = 0;
+
+    public int dfs(boolean[] visited, int cnt, int cur, int flag){
+
+        int tmp = cnt;
+        for(int nxt : adj[cur][flag]){
+            if(visited[nxt]) continue;
+            visited[nxt] = true;
+            tmp++;
+            tmp += dfs(visited, cnt, nxt, flag);
+        }
+        return tmp;
+    }
+
+    public void simulation(){
+        int win,lose;
+        for(int i=1; i<= N; i++){
+            boolean[] visited = new boolean[N+1];
+            visited[i] = true;
+            win = dfs(visited, 0,i,0);
+            lose = dfs(visited,0,i,1);
+
+            if(win + lose == N-1) answer++;
+        }
+    }
+    public int solution(int n, int[][] results) {
+        N = n;
+        adj = new ArrayList[N+1][2];
+        for(int i=0; i<= N; i++)
+            for(int j=0; j<2; j++)
+                adj[i][j] = new ArrayList<>();
+
+        for(int i=0; i<results.length; i++){
+            int win = results[i][0];
+            int lose = results[i][1];
+            adj[win][0].add(lose);
+            adj[lose][1].add(win);
+        }
+
+        simulation();
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#178 


## 📝 문제 풀이 전략 및 실제 풀이 방법
### DFS,백트랙킹
한 선수가 이긴 선수들, 진 선수들 합이 N-1 이되면 순위가 결정됩니다. 또한, 만약 2번 선수가 1,3번 선수를 이기고 5번 선수가 2번 선수를 이겼다면 5번 선수는 2,1,3번 선수 모두를 이긴 것이 됩니다. 따라서, 이를 구현하고자 DFS 를 이용하여 깊이 탐색을 해 이긴 선수와 진 선수의 합이 N-1 이면 정답을 +1 해주었습니다. 

인접 리스트는 2차원을 이용하여 [선수번호][2] 로 하여 두번째 좌표는 0 : 이김, 1:짐 으로 표시해주었습니다.
DFS를 돌면서 백트랙킹으로 방문하지 선수들의 갯수를 리턴하여 가능한 선수들의 수를 세어주었습니다.

## 🧐 참고 사항
.

## 📄 Reference
.
