### PR TITLE
PGMS_241108_순위

### DIFF
--- a/hoo/november/week2/PGMS_241108_순위.java
+++ b/hoo/november/week2/PGMS_241108_순위.java
@@ -1,0 +1,57 @@
+import java.util.*;
+
+class Solution {
+
+    public int solution(int n, int[][] results) {
+        int answer = judgeRanking(n, results);
+
+        return answer;
+    }
+
+    int judgeRanking(int n, int[][] results) {
+        int[][] rankingArr = new int[n+1][n+1]; // 각 선수의 부모노드까지 거리를 저장할 배열
+        int[][] reverseRankingArr = new int[n+1][n+1];  // 각 선수의 자식 노드까지 거리를 저장할 배열
+        int INF = 100 * 100 + 1;    // 거리의 최댓값 : n * n
+        for (int i = 0; i <= n; i++) {
+            for (int j = 0; j <= n; j++) {
+                if (i != j) {
+                    rankingArr[i][j] = INF;  // 자기 자신 제외 최댓값으로 초기화
+                    reverseRankingArr[i][j] = INF;
+                }
+            }
+        }
+        int from, to;   // from: 이긴 사람, to: 진 사람
+        for (int i = 0; i < results.length; i++) {  // 일단 주어진 승부에 따라 승부 저장
+            from = results[i][0];
+            to = results[i][1];
+            rankingArr[to][from] = 1;   // 진 사람에게 결과를 저장함, 이러면 0이 아닌 값은 부모 노드까지의 거리를 표시하게 됨
+            reverseRankingArr[from][to] = 1;    // 이긴 사람에게 결과를 저장함, 이러면 0이 아닌 값은 자식 노드까지의 거리를 표시하게 됨
+        }
+
+        for (int k = 1; k <= n; k++) {  // 플로이드 워셜 알고리즘 이용하여 유향 그래프의 각 노드간 거리 계산. k는 경유지
+            for (int i = 1; i <= n; i++) {  // i는 출발지
+                for (int j = 1; j <= n; j++) {  // j는 도착지
+                    rankingArr[i][j] = Math.min(rankingArr[i][j], rankingArr[i][k] + rankingArr[k][j]);
+                    reverseRankingArr[i][j] = Math.min(reverseRankingArr[i][j], reverseRankingArr[i][k] + reverseRankingArr[k][j]); // 바로 가는 경로와 경유지 거쳐서 가는 경로 중 작은 값을 저장
+                }
+            }
+        }
+
+        int answer = 0;
+        int[] playerRank, playerReverseRank;
+        for (int i = 1; i <= n; i++) {  // 1번 선수부터 시작
+            playerRank = rankingArr[i];
+            playerReverseRank = reverseRankingArr[i];
+            int connectedCount = 0; // 부모, 자식 개수 합
+            for (int j = 1; j <= n; j++) {
+                if (j == i) continue;
+                if (playerRank[j] != INF || playerReverseRank[j] != INF) connectedCount++;  // 부모나 자식이면 카운트 +1
+            }
+            if (connectedCount == n-1) answer++;    // 부모 선수 + 자식 선수 값이 n-1이면 순위를 판별할 수 있으므로 정답+1
+        }
+
+
+        return answer;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #178 

## 📝 문제 풀이 전략 및 실제 풀이 방법
문제에서 모든 경기 결과에 모순이 없다고 했으므로 싸이클이 없는 유향그래프가 주어진다는 것을 파악했습니다. 여기서 떠올린 풀이법은 1. 위상 정렬, 2. 플로이드 워셜, 3. 탐색 과 같았습니다. 위상 정렬의 경우 그림을 그려보니 어떻게 노드 개수를 카운트 할 지 떠오르지 않았고, 플로이드 워셜의 경우 유향이므로 부모까지의 거리, 자식까지의 거리를 따로 저장한다면 카운트가 가능할 것 같았으며 시간복잡도 역시 n이 100이었으므로 n^3안에 해결이 가능하다고 판단이 들어 이를 이용해서 풀이했습니다.
그렇게 부모(자신을 이긴 선수)까지의 거리(1이면 직접 붙어본 선수 2 이상이면 자신에게 이긴 선수를 이긴 선수)와 자식(자신에게 진 선수)까지의 거리(부모의 반대)를 저장하는 배열을 각각 두고 배열 각각에 대해 플로이드 워셜을 통해 거리를 저장해주었습니다. 이때 두 배열에 값의 저장은 단순히 from, to를 to, from으로 바꾸는 식으로만 해주면 되므로 한 번의 반복문에서 같이 값을 갱신시켰습니다.
이후 최종적으로 각 선수들에 대해 부모, 자식까지의 거리 배열을 돌며 승부 파악이 가능한 선수 카운트가 n-1이면 순위를 결정할 수 있으므로 정답에 카운트+1씩을 해주어 정답을 구했습니다.

## 🧐 참고 사항


## 📄 Reference
