### PR TITLE
BOJ_241109_하늘에서 별똥별이 빗발친다

### DIFF
--- a/hoo/november/week2/Main_14658_하늘에서별똥별이빗발친다.java
+++ b/hoo/november/week2/Main_14658_하늘에서별똥별이빗발친다.java
@@ -1,0 +1,62 @@
+package november.week2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main_14658_하늘에서별똥별이빗발친다 {
+
+    static int N, M, L, K;
+    static List<int[]> commetList;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        setTrampoline();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        commetList = new ArrayList<>(); // 별똥별 좌표 저장
+        int x, y;
+        for (int i = 0; i < K; i++) {
+            st = new StringTokenizer(br.readLine());
+            x = Integer.parseInt(st.nextToken());
+            y = Integer.parseInt(st.nextToken());
+            commetList.add(new int[] {x, y});
+        }
+    }
+
+    static void setTrampoline() {
+        int answer = K;
+
+        int startX, startY, endX, endY; // 트램펄린의 좌하단 꼭지점 좌표
+        for (int i = 0; i < commetList.size(); i++) {   // 모든 별똥별의 좌표에 대해, 이 별의 x좌표를 트램펄린의 왼쪽 모서리 x좌표로 두고
+            for (int j = 0; j < commetList.size(); j++) {   // 다른 별의 y좌표를 트램펄린의 아래 모서리 y좌표로 둠.
+                startX = commetList.get(i)[0];
+                startY = commetList.get(j)[1];
+                endX = startX + L;
+                endY = startY + L;
+
+                int coverCount = 0; // 지금의 트램펄린이 튕겨낼 수 있는 별 개수
+                int[] commet;
+                for (int k = 0; k < K; k++) {   // 모든 별들에 대해서
+                    commet = commetList.get(k);
+                    if ( (startX <= commet[0] && commet[0] <= endX)
+                            && (startY <= commet[1] && commet[1] <= endY) ) coverCount++;   // 트램펄린 범위 안이면 카운트 + 1
+                }
+                answer = Math.min(answer, K-coverCount);    // 정답 갱신
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #181 

## 📝 문제 풀이 전략 및 실제 풀이 방법
처음에는 한 별의 좌표를 원점으로 잡고, 그 점을 기준으로 4개의 사분면을 트램펄린으로 가정한 뒤 그 안에 들어오는 별들을 체크해주었습니다. 하짐나 틀리게 되어 반례를 보니, 별이 꼭짓점이 아닌 모서리에 걸쳐있는 상황(이렇게 된다면 두 모서리에 별이 하나 이상씩 걸쳐 있게 됨)이 최대가 될 수도 있었습니다.
이후 한 별의 x좌표를 왼쪽 모서리 x좌표로 잡고, 다른 별의 y좌표를 아래 모서리 y좌표로 하는 트램펄린을 만들어 각 별이 그 범위안에 포함되는 지 파악해보았습니다. 앞 문장에서 한 것과 같이 하면 해당 x, y를 왼쪽 아래 꼭지점으로 하는 트램펄린을 만들 수 있으며, 각 별이 그 트램펄린의 범위 내에 있는 지 체크하여 범위 내라면 카운트를 +1 해주었습니다. 이후 별의 개수 - 카운트 값의 최소 값을 갱신해주며 최종적으로 출력해주었습니다.

## 🧐 참고 사항
![image](https://github.com/user-attachments/assets/15b9adc8-a183-4015-9793-9502a5a6d2e0)
이해에 도움이 될까하여 그림 첨부해요.. 총총,,,

## 📄 Reference
