### PR TITLE
BOJ_241112_고층건물

### DIFF
--- a/hoo/november/week3/Main_1027_고층건물.java
+++ b/hoo/november/week3/Main_1027_고층건물.java
@@ -1,0 +1,63 @@
+package november.week3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_1027_고층건물 {
+
+    static int N;
+    static int[] buildings;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        countCanSee();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        buildings = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) buildings[i] = Integer.parseInt(st.nextToken());
+    }
+
+    static void countCanSee() {
+        int maxCanSee = 0;
+        int INF = 1_000_000_000;    // 빌딩 높이 최댓값
+
+        double leftGradient, rightGradient, tempGradient;    // 현재 건물 기준 왼쪽, 오른쪽의 절대값이 가장 큰 기울기 저장하는 변수
+        int canSeeCount;
+        for (int i = 0; i < N; i++) {
+            canSeeCount = 0;
+            leftGradient = INF * 1.0; // 왼쪽 기울기 초기값은 기울기 차이 최댓값의 양수값으로
+            int xDiff, yDiff;
+            for (int j = i-1; j >= 0; j--) {   // 현재 건물 왼쪽에 대해 수행
+                xDiff = i-j;
+                yDiff = buildings[i]-buildings[j];
+                tempGradient = (yDiff*1.0)/(xDiff*1.0);
+                if (leftGradient > tempGradient) {    // 왼쪽에 있는 빌딩들은 기울기가 같거나 증가하면 볼 수 없게 되는 것임
+                    leftGradient = tempGradient;
+                    canSeeCount++;
+                }
+            }
+//            System.out.println(canSeeCount);
+            rightGradient = INF * -1.0; // 오른쪽 기울기 초기값은 기울기 차이 최댓값의 음수 값으로
+            for (int j = i+1; j < N; j++) { // 현재 건물 오른쪽에 대해 수행
+                xDiff = j-i;
+                yDiff = buildings[j]-buildings[i];
+                tempGradient = (yDiff*1.0)/(xDiff*1.0);
+                if (rightGradient < tempGradient) {    // 오른쪽에 있는 빌딩들은 기울기가 같거나 감소하면 볼 수 없게 되는 것임
+                    rightGradient = tempGradient;
+                    canSeeCount++;
+                }
+            }
+//            System.out.println(i + " " + canSeeCount);
+//            System.out.println("==================");
+            maxCanSee = Math.max(maxCanSee, canSeeCount);
+        }
+        System.out.println(maxCanSee);
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #186 

## 📝 문제 풀이 전략 및 실제 풀이 방법
모든 건물을 순회하며 현재 건물을 기준으로 왼쪽 건물들, 오른쪽 건물들을 순차적으로 봐줍니다. 각 순회에서는 각 시점의 기울기를 이용해 조건을 처리해줍니다.
왼쪽 건물들에 대해서는 현재 건물과 가까운 건물부터 0번 위치의 건물까지 각 건물의 기울기를 구해줍니다. 기준 기울기의 최솟값보다 더 작은 값의 기울기(음수 포함)가 나타난다면, 그 건물은 볼 수 있는 건물임을 카운트해주며 기준 기울기를 그 값으로 갱신합니다.
오른쪽 건물들에 대해서는 현재 건물과 가까운 건물부터 N-1번 위치의 건물까지 각 건물의 기울기를 구해줍니다. 기준 기울기의 최댓값보다 더 큰 값의 기울기(음수 포함)가 나타난다면, 그 건물은 볼 수 있는 건물임을 카운트해주며 기준 기울기를 그 값으로 갱신합니다.
이와 같은 로직을 모든 건물에 대해 수행해주며 볼 수 있는 건물 개수의 최댓값을 갱신해주어 최종 값을 출력해주어 문제를 해결했습니다.

## 🧐 참고 사항


## 📄 Reference
