### PR TITLE
BOJ_241114_A와B2

### DIFF
--- a/hyun/11_november/BOj_241114_A와B2.java
+++ b/hyun/11_november/BOj_241114_A와B2.java
@@ -1,0 +1,49 @@
+package bfs;
+
+import java.io.*;
+import java.util.*;
+public class BOj_241114_A와B2 {
+    static String S,T;
+
+    public static boolean isAnswer(String S){
+        if(S.equals(S)) return true;
+        return false;
+    }
+    public static int simulation(){
+        Queue<String> q = new ArrayDeque<>();
+        Set<String> visited = new HashSet<>();
+
+        q.add(T);
+        visited.add(T);
+
+        while(!q.isEmpty()){
+            String cur = q.poll();
+
+            if(cur.length() == S.length()){
+                // 정답 확인
+                if(isAnswer(cur)) return 1;
+                continue;
+            }
+
+            int len = cur.length();
+            if(cur.charAt(len-1) == 'A'){
+                q.add(cur.substring(0,len-1));
+            }
+
+            if(cur.charAt(0) == 'B'){
+                StringBuffer sb = new StringBuffer(cur);
+                String tmp = sb.reverse().toString();
+                q.add(tmp.substring(0,len-1));
+            }
+        }
+
+        return 0;
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        S = br.readLine();
+        T = br.readLine();
+
+        System.out.println(simulation());
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#193 


## 📝 문제 풀이 전략 및 실제 풀이 방법
문제에선 S를 T로 바꿀 수 있는지 물었지만, 문제에서 말한대로 구현을 하면 메모리 초과 납니다. S에서 두가지를 선택하며 T로 접근했을시에 시간복잡도는 2^50 r까지 시간복잡도가 소요되므로 시간초과가 날 가능성이 있었습니다. (실제로 처음에 이방법으로 시도했는데, 메모리 초과가 먼저 발생하였습니다. )
따라서, T를 S로 만들어주었습니다. 맨 마지막 문자가 A 일때는 이전 상황에서 맨 뒤에 A 를 붙힌 경우이므로 A를 제거해주고 맨 앞 문자가 B 일때는 뒤집어지고 맨 마지막 B를 제거한 경우에서 온 문자열입니다. 따라서 이렇게 하나씩 제거해주다가 길이가 S 랑 똑같을 시에는 문자열 비교를 하여 같을시엔 바로 정답 처리해주었습니다.

## 🧐 참고 사항
.
## 📄 Reference
.
