### PR TITLE
BOJ_241115_알고리즘수업-깊이우선탐색3

### DIFF
--- a/hyun/11_november/BOJ_241115_알고리즘수업_깊이우선탐색3.java
+++ b/hyun/11_november/BOJ_241115_알고리즘수업_깊이우선탐색3.java
@@ -1,0 +1,62 @@
+package dfs;
+
+import java.io.*;
+import java.util.*;
+public class BOJ_241115_알고리즘수업_깊이우선탐색3 {
+    static int N,M,R;
+    static ArrayList<Integer>[] adj;
+    static boolean[] visited;
+    static int[] answer;
+    static StringBuilder sb = new StringBuilder();
+
+    public static void dfs(int cur, int cnt){
+
+        for(int nxt : adj[cur]){
+            if(visited[nxt]) continue;
+
+            visited[nxt] = true;
+            answer[nxt] = cnt+1;
+            dfs(nxt, cnt+1);
+        }
+    }
+
+    public static void simulation(){
+        for (int i = 0; i <= N; i++) {
+            Collections.sort(adj[i]);
+        }
+        visited = new boolean[N+1];
+        answer = new int[N+1];
+        Arrays.fill(answer,-1);
+
+        visited[R] = true;
+        answer[R] = 0;
+        dfs(R,0);
+
+        for (int i = 1; i <= N ; i++) sb.append(answer[i]).append("\n");
+        System.out.println(sb);
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+
+        adj = new ArrayList[N+1];
+        for (int i = 0; i <= N; i++) {
+            adj[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            adj[a].add(b);
+            adj[b].add(a);
+        }
+
+        simulation();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#196 


## 📝 문제 풀이 전략 및 실제 풀이 방법
각 정점의 깊이를 담아줄 1차원 배열을 -1로 세팅해두고 정점 R부터 시작해서 dfs 를 수행해주었습니다. 이때, dfs 수행하기 전 인접 리스트 안의 정점들을 미리 오름차순으로 정렬한 후 dfs 를 돌면서 다음 정점이 방문하지 않은 상태이면 방문 처리해준후, 정답 배열에 깊이를 기록하면서 깊이 우선 탐색을 수행해주었습니다.

## 🧐 참고 사항
.

## 📄 Reference
.
