### PR TITLE
BOJ_241117_문자열폭발

### DIFF
--- a/hyun/11_november/BOJ_241116_문자열폭발.java
+++ b/hyun/11_november/BOJ_241116_문자열폭발.java
@@ -4,17 +4,11 @@ import java.util.*;
 
 // v1 : substring 활용
 // v2 : 연결리스트 처럼 구현
+// v3 : 스택
 public class Main {
     static String explode;
     static char[] input;
     static int[] nxt;
-    public static void makeNextIdx(){
-        nxt = new int[input.length];
-        for (int i = 0; i < input.length; i++) {
-            nxt[i] = i+1;
-        }
-        nxt[input.length-1] = -1; // 마지막 표시
-    }
 
     public static void explode(){
         Stack<Character> st = new Stack<>();
@@ -31,18 +25,18 @@ public class Main {
 
                 if(st.size() < explode.length()) continue;
                 else {
-                    tmp = new Stack<>();
+                    int stIdx = st.size()-1;
                     int exIdx = explode.length()-1; // explode 기준
 
                     for (int j = 0; j < explode.length(); j++) {
-                        char cur = st.pop();
-                        if(cur != explode.charAt(exIdx--)) isExplode = false;
-                        tmp.add(cur);
+                        if(st.get(stIdx--) != explode.charAt(exIdx--)) isExplode = false;
                     }
                 }
 
-                if(!isExplode){
-                    while(!tmp.isEmpty()) st.add(tmp.pop());
+                if(isExplode){
+                    for (int j = 0; j < explode.length(); j++) {
+                        st.pop();
+                    }
                 }
 
             }
@@ -59,7 +53,6 @@ public class Main {
 
     }
     public static void simulation(){
-        //makeNextIdx();
         explode();
     }
     public static void main(String[] args) throws Exception{

--- a/hyun/11_november/BOJ_241116_문자열폭발.java
+++ b/hyun/11_november/BOJ_241116_문자열폭발.java
@@ -1,0 +1,72 @@
+import javax.swing.plaf.basic.BasicBorders;
+import java.io.*;
+import java.util.*;
+
+// v1 : substring 활용
+// v2 : 연결리스트 처럼 구현
+public class Main {
+    static String explode;
+    static char[] input;
+    static int[] nxt;
+    public static void makeNextIdx(){
+        nxt = new int[input.length];
+        for (int i = 0; i < input.length; i++) {
+            nxt[i] = i+1;
+        }
+        nxt[input.length-1] = -1; // 마지막 표시
+    }
+
+    public static void explode(){
+        Stack<Character> st = new Stack<>();
+        Stack<Character> tmp;
+
+
+        char end = explode.charAt(explode.length()-1);
+        for(int i=0; i<input.length; i++){
+            char ch = input[i];
+            st.add(ch);
+
+            if(ch == end){ // 스택에서 빼주기
+                boolean isExplode = true;
+
+                if(st.size() < explode.length()) continue;
+                else {
+                    tmp = new Stack<>();
+                    int exIdx = explode.length()-1; // explode 기준
+
+                    for (int j = 0; j < explode.length(); j++) {
+                        char cur = st.pop();
+                        if(cur != explode.charAt(exIdx--)) isExplode = false;
+                        tmp.add(cur);
+                    }
+                }
+
+                if(!isExplode){
+                    while(!tmp.isEmpty()) st.add(tmp.pop());
+                }
+
+            }
+        }
+
+
+        if(st.isEmpty()) System.out.println("FRULA");
+        else{
+            StringBuilder sb = new StringBuilder();
+            for(char c : st) sb.append(c);
+            System.out.println(sb);
+        }
+
+
+    }
+    public static void simulation(){
+        //makeNextIdx();
+        explode();
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        input = br.readLine().toCharArray();
+        explode = br.readLine();
+
+        simulation();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#199 


## 📝 문제 풀이 전략 및 실제 풀이 방법
입력 문자열을 순회하며 우선, 스택에 담아준 후 담은 문자가 폭바열 문자의 제일 끝 문자와 같다면 스택에서 폭발 문자열이 있는지 봐주었습니다. 
이때, 스택을 배열처럼 접근할 수 있는 방법을 몰랐어서 별도의 스택을 하나 더 두어 무조건 스택에서 폭발 문자열 길이만큼 옮겨주다가 폭발 문자열과 일치하지 않으면 불리언 플래그값을 false 로 표시해주었습니다. 이렇게 이동 작업이 끝나고 불리언 플래그 값을 확인하여 false 라면 다시 스택에 문자열을 넣어주었습니다. 

이후 다른 사람의 풀이를 보다가 스택을 배열처럼 접근할 수 있는 방법을 알고 별도의 스택을 두지 않고 했더니, 시간이 줄어들었습니다. 

## 🧐 참고 사항
마지막에 스택에서 모든 문자를 꺼내서 String + <-- 이렇게 쌓아주었는데 메모리 초과가 나왔습니다 .. 이유를 말하라면 잘 모르겟습니다. . 그저 비효율적이란 말 밖에 ..? 하지만 왜 비효율적일까요 .. 이제 알아보겠습니다 ..

## 📄 Reference

