### PR TITLE
BOJ_241126_보물섬 && PGMS_241127_과일장수

### DIFF
--- a/hyun/11_november/BOJ_241127_보물섬.java
+++ b/hyun/11_november/BOJ_241127_보물섬.java
@@ -1,0 +1,69 @@
+package bfs;
+
+import java.io.*;
+import java.util.*;
+public class BOJ_241127_보물섬 {
+    static int N,M;
+    static char[][] input;
+    static int answer = 0;
+    static int[] dx = {-1,1,0,0};
+    static int[] dy = {0,0,-1,1};
+
+    static class Node{
+        int x,y;
+        Node(int x, int y){
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    static void bfs(int x, int y){
+        Queue<Node> q = new ArrayDeque<>();
+        int[][] visited = new int[N][M];
+
+        q.add(new Node(x,y));
+        visited[x][y] = 1;
+
+        while(!q.isEmpty()){
+            Node cur = q.poll();
+            answer = Math.max(answer, visited[cur.x][cur.y]);
+
+            for (int k = 0; k < 4; k++) {
+                int nx = cur.x + dx[k];
+                int ny = cur.y + dy[k];
+
+                if(nx < 0 || nx >= N || ny < 0 || ny >= M ||
+                        input[nx][ny] != 'L' || visited[nx][ny] != 0 ) continue;
+
+                q.add(new Node(nx,ny));
+                visited[nx][ny] = visited[cur.x][cur.y] + 1;
+            }
+        }
+    }
+    static void simulation(){
+
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if(input[i][j] == 'L')
+                    bfs(i,j);
+            }
+        }
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        input = new char[N][M];
+        for (int i = 0; i < N; i++) {
+            input[i] = br.readLine().toCharArray();
+        }
+
+        simulation();
+
+        System.out.println(answer - 1);
+    }
+}

--- a/hyun/11_november/PGMS_241127_과일장수.java
+++ b/hyun/11_november/PGMS_241127_과일장수.java
@@ -1,0 +1,16 @@
+package sort;
+
+import java.util.*;
+
+public class PGMS_241127_과일장수 {
+    public int solution(int k, int m, int[] score) {
+        int answer = 0;
+
+        Arrays.sort(score);
+
+        for(int i=score.length-m; i>=0 ; i-=m ) {
+            answer += (score[i]*m);
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#220 
#222 


## 📝 문제 풀이 전략 및 실제 풀이 방법
입력 배열에서 Land 일때마다 bfs를 수행후 방문배열을 int 로 설정하면서 지나왔던 경로들을 +1 해주면서 제일 큰 값을 정답에 갱신해주었습니다. 

-------------------------------------------------------
한 과일 박스마다 높은 점수들이 하나씩 들어가면 되서, 입력 배열을 오름차순으로 정렬한 뒤 뒤부터 m개씩 한상자에 넣으면서 점수 계산을 해주었습니다.

## 🧐 참고 사항
.

## 📄 Reference
### 보물섬 문제
제껀 시간이 448ms 인데 아래 첨부한 링크의 코드는 160ms 가 걸리더라구요 ?!
다른 점은 밑의 코드의 아이디어는 땅들을 한 덩어리라고 쳤을때 한 덩어리에서 땅마다 bfs 를 도는것이 아니라 땅들 덩어리에서 제일 바깥쪽 점들을 모두 다 따준 후에 그 점들에서 bfs 를 도는 것에 차이가 있었습니당
[160ms_코드링크](https://www.acmicpc.net/source/86876310)

