### PR TITLE
PGMS_241204_실패율

### DIFF
--- a/hoo/december/week2/PGMS_241204_실패율.java
+++ b/hoo/december/week2/PGMS_241204_실패율.java
@@ -1,0 +1,48 @@
+import java.util.*;
+
+class Solution {
+
+    public int[] solution(int N, int[] stages) {
+        int[] answer = calcFailures(N, stages);
+
+        return answer;
+    }
+
+    int[] calcFailures(int N, int[] stages) {
+        // 1, 3, 2, 1, 0 + 1
+
+        // 1 + 0, 1, 2, 3, 1    5~1 역순
+        // [1, 0, 1, 2, 3, 1]
+        // [1, 1, 2, 4, 7, 8]
+        // 1 + 1, 2, 4, 7, 8
+        Arrays.sort(stages);    // stages 오름차순으로 정렬
+        int[] sumArr = new int[N+2];    // 1~N까지 스테이지 클리어 유저 수의 누적합 저장하기 위한 배열
+        int[] clearArr = new int[N+2];  // 해당 스테이지를 클리어한 유저 수 저장하는 배열
+        for (int i = stages.length-1; i >= 0; i--) clearArr[(N+1)-stages[i]]++;
+        sumArr[0] = clearArr[0];
+        for (int i = 1; i < clearArr.length; i++) sumArr[i] = sumArr[i-1] + clearArr[i];
+
+        PriorityQueue<float[]> pq = new PriorityQueue<>(new Comparator<float[]>() {
+            @Override
+            public int compare(float[] f1, float[] f2) {
+                if (f2[0] == f1[0]) return Float.compare(f1[1], f2[1]);   // 실패율 같은 것들끼리는 스테이지 번호 기준 오름차순 정렬
+                return Float.compare(f2[0], f1[0]);   // 실패율 기준 내림차순 정렬
+            }
+        });
+        for (int i = 1; i < clearArr.length-1; i++) {
+            if (sumArr[i] == 0) pq.offer(new float[] {0, N+1 - i}); // 누적합이 0인 경우 고려
+            else pq.offer(new float[] {(clearArr[i]*1.0f / sumArr[i]*1.0f), N+1 - i});
+        }
+        int[] answer = new int[N];
+        int index = 0;
+        while (!pq.isEmpty()) {
+            float[] arr = pq.poll();
+            // System.out.println(Arrays.toString(arr));
+            answer[index++] = (int) arr[1];
+        }
+
+
+        return answer;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #237 

## 📝 문제 풀이 전략 및 실제 풀이 방법
우선, stages의 길이가 20만임을 고려하여 가급적 1차원 순회로만 해결하고자 했습니다. 그리하여 각 스테이지 별 클리어 사용자 수, 누적 클리어 사용자 수를 저장하는 배열을 만들고 값을 저장해주었습니다.
이를 이용해 실패율이 높은 순으로 정답을 출력해주고자, PriorityQueue를 사용했습니다. 조건은 문제에서 준 조건대로 주었으며, float[] 타입의 Comparator를 타입으로 주었습니다. PQ에 삽입 시, 실패율 계산에 사용되는 분모인 누적합 배열의 값이 0이라면, zero divisior error가 발생할 수 있으므로, 그에 대한 처리를 실패율이 0인 경우라고 해주어 해결했습니다.

## 🧐 참고 사항


## 📄 Reference
