### PR TITLE
BOJ_241205_국회의원 선거

### DIFF
--- a/hoo/december/week2/Main_1417_국회의원선거.java
+++ b/hoo/december/week2/Main_1417_국회의원선거.java
@@ -1,0 +1,43 @@
+package december.week2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+public class Main_1417_국회의원선거 {
+
+    static int N;
+    static int dasomVotes;
+    static PriorityQueue<Integer> otherVotes;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        calcMinMaesu();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        dasomVotes = Integer.parseInt(br.readLine());
+        otherVotes = new PriorityQueue<>(Collections.reverseOrder());   // 투표 수 내림차순 정렬하는 우선순위 큐
+        for (int i = 1; i < N; i++) otherVotes.offer(Integer.parseInt(br.readLine()));
+    }
+
+    static void calcMinMaesu() {
+        int maesuCount = 0;
+        while (true) {
+            if (otherVotes.isEmpty() || otherVotes.peek() < dasomVotes) break;  // 다솜이의 득표수가 가장 많아지면 종료
+            int now = otherVotes.poll();
+            now--;
+            dasomVotes++;
+            maesuCount++;
+            otherVotes.offer(now);
+        }
+
+        System.out.println(maesuCount);
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #239 

## 📝 문제 풀이 전략 및 실제 풀이 방법
다솜이의 투표 수를 저장하는 변수와 다른 사람들의 투표수를 따로 저장, 가장 높은 투표 수가 다솜이의 투표수보다 낮아질 때까지 한 표씩을 뺏어오는 식의 그리디한 방식으로 풀이했습니다.
첫 풀이는 다른 사람들의 투표 수를 배열에 담아 정렬 후 다솜이의 투표수보다 높은 사람들의 표를 하나씩 뺏어오는 것을 반복하는 식으로 풀이했으나, 이는 매 반복마다 정렬을 해줬어야 했습니다. 이는 비효율적인 풀이라는 것이란 생각이 들어 우선 순위 큐를 이용, 내림차순 정렬하여 가장 위의 투표 수에서 한 표씩을 뺏어오는 것을 반복하는 풀이로 변경하여 해결했습니다.

## 🧐 참고 사항


## 📄 Reference
