### PR TITLE
Hyun

### DIFF
--- a/hyun/12_december/BOJ_241207_크로스컨트리.java
+++ b/hyun/12_december/BOJ_241207_크로스컨트리.java
@@ -1,0 +1,101 @@
+package implementation;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_241207_크로스컨트리 {
+
+    static int N;
+    static int total;
+    static int[] input;
+    static StringBuilder sb = new StringBuilder();
+
+    static class Node{
+        int sum, cnt, five;
+        Node(int sum, int cnt, int five){
+            this.sum = sum;
+            this.cnt = cnt;
+            this.five = five;
+        }
+    }
+
+    public static void countTeam(int[] counting){
+        for(int i=0; i<N; i++){
+            counting[input[i]]++;
+        }
+    }
+
+    public static void calScore(int[] counting, HashMap<Integer,Node> hmap){
+        for(int i=1; i<=total; i++){
+            if(counting[i] == 6) hmap.put(i, new Node(0,0,0));
+        }
+
+        int score = 1;
+        for(int team : input){
+            if(hmap.containsKey(team)){
+                Node cur = hmap.get(team);
+                if(cur.cnt < 4) cur.sum += score;
+                else if(cur.cnt == 4) cur.five = score;
+
+                cur.cnt += 1;
+                score++;
+                hmap.put(team,cur);
+            }
+        }
+
+        int sum = Integer.MAX_VALUE;
+        int team = 0;
+        int five = Integer.MAX_VALUE;
+        for(int t : hmap.keySet()){
+            Node cur = hmap.get(t);
+
+            if(sum >= cur.sum){
+                if(sum > cur.sum) {
+                    sum = cur.sum;
+                    team = t;
+                    five = cur.five;
+                }
+                else{
+                    if(five > cur.five){
+                        team = t;
+                        five = cur.five;
+                    }
+                }
+            }
+        }
+
+        sb.append(team).append("\n");
+    }
+
+    public static void simulation(){
+        int[] counting = new int[total+10];
+        HashMap<Integer,Node> hmap = new HashMap<>();
+
+        countTeam(counting);
+        calScore(counting, hmap);
+    }
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+
+        for(int tc=0; tc<T; tc++){
+            N = Integer.parseInt(br.readLine());
+            st = new StringTokenizer(br.readLine());
+            input = new int[N];
+            total = 0;
+
+            for(int i=0; i<N; i++){
+                input[i] = Integer.parseInt(st.nextToken());
+                total = Math.max(total, input[i]);
+            }
+
+            simulation();
+        }
+
+        System.out.println(sb);
+    }
+
+}

--- a/hyun/12_december/PGMS_241211_없어진기록찾기.sql
+++ b/hyun/12_december/PGMS_241211_없어진기록찾기.sql
@@ -1,0 +1,7 @@
+package sql;
+
+
+SELECT ANIMAL_ID, NAME
+from ANIMAL_OUTS
+where ANIMAL_ID not in (select ANIMAL_ID from ANIMAL_INS)
+gi

--- a/hyun/12_december/PGMS_241211_지폐접기.java
+++ b/hyun/12_december/PGMS_241211_지폐접기.java
@@ -1,0 +1,27 @@
+package implementation;
+
+public class PGMS_241211_지폐접기 {
+    public int solution(int[] wallet, int[] bill) {
+        int answer = 0;
+
+        int minW, maxW;
+        int minB, maxB;
+
+        while(true){
+            minW = Math.min(wallet[0], wallet[1]);
+            maxW = Math.max(wallet[0], wallet[1]);
+
+            minB = Math.min(bill[0], bill[1]);
+            maxB = Math.max(bill[0], bill[1]);
+
+            if(minW >= minB && maxW >= maxB) break;
+
+            if(bill[0] > bill[1]) bill[0] /= 2;
+            else bill[1] /= 2;
+
+            answer++;
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#245 
#247 
#248 


## 📝 문제 풀이 전략 및 실제 풀이 방법
### 크로스 컨트리
1. 입력 배열에서 팀마다 인원수를 세어줌
2. 한팀이 6명이라면 해쉬맵에 팀 번호를 키로 하여 저장함
    - 이때, 키값은 Node 로 하는데 여기엔 상위 4명의 점수 합, 5등의 점수를 저장함
3. 입력 배열을 다시 순회하며 해시맵에 해당 팀이 존재하면 점수를 저장해줌
4. 해시맵에 다시 순회를 하면서 1등 팀을 선발함

### 지폐 접기
반복문을 돌며 wallet과 bill 의 최솟값 최댓값이 wallet >= bill 이면 반복을 종료하고, 그렇지 않으면 지폐를 접어주는 식으로 구현함

### 없어진 기록 찾기
ANIMAL_OUTS 에서 ANIMAL_INS 에 없는 동물들을 출력해주므로 not in 을 사용함

## 🧐 참고 사항
.

## 📄 Reference
.
