### PR TITLE
PGMS_241213_추억 점수 & PGMS_241216_헤비 유저가 소유한 장소

### DIFF
--- a/hoo/december/week3/PGMS_241213_추억점수.java
+++ b/hoo/december/week3/PGMS_241213_추억점수.java
@@ -1,0 +1,33 @@
+import java.util.*;
+
+class Solution {
+
+    public int[] solution(String[] name, int[] yearning, String[][] photo) {
+        int[] answer = calcScore(name, yearning, photo);
+
+        return answer;
+    }
+
+    int[] calcScore(String[] name, int[] yearning, String[][] photo) {
+        Map<String, Integer> yearningMap = makeYearningMap(name, yearning);
+        int[] scores = new int[photo.length];
+        for (int i = 0; i < photo.length; i++) {
+            int temp = 0;
+            for (int j = 0; j < photo[i].length; j++) {
+                if (!yearningMap.containsKey(photo[i][j])) continue;    // 그리움 점수에 없는 사람은 건너 뜀
+                temp += yearningMap.get(photo[i][j]);
+            }
+            scores[i] = temp;
+        }
+
+        return scores;
+    }
+
+    Map<String, Integer> makeYearningMap(String[] name, int[] yearning) {
+        Map<String, Integer> yearningMap  = new HashMap<>();
+        for (int i = 0; i < name.length; i++) yearningMap.put(name[i], yearning[i]);
+
+        return yearningMap;
+    }
+
+}

--- a/hoo/december/week4/PGMS_241216_헤비유저가소유한장소.sql
+++ b/hoo/december/week4/PGMS_241216_헤비유저가소유한장소.sql
@@ -1,0 +1,8 @@
+select *
+from places
+where host_id in
+(select host_id
+    from places
+    group by host_id
+    having count(name) >= 2)
+order by id;


### PR DESCRIPTION
## 🔍 개요
+ #250 

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 추억 점수
우선 각 사람의 추억 점수를 저장하는 Map을 생성했습니다. 
이후 각 사진의 사람마다 순회하며 이 추억 점수 map에 있는 사람이라면 점수를 더해주어 해당 사진의 점수를 측정하는 방식으로 풀이했습니다.
---
+ 헤비 유저가 소유한 장소
우선 헤비 유저를 선별하는 서브 쿼리를 사용하여 헤비 유저의 host_id를 조회합니다. 그렇게 조회된 헤비 유저의 id에 해당하는 row들만 places 테이블에서 조회해오기 위해 "where host_id in 서브쿼리 결과"를 사용해주었습니다.

## 🧐 참고 사항


## 📄 Reference
