### PR TITLE
BOJ_241226_List Of Unique Numbers

### DIFF
--- a/hyun/12_december/BOJ_241226_ListOfUniqueNumbers.java
+++ b/hyun/12_december/BOJ_241226_ListOfUniqueNumbers.java
@@ -1,0 +1,48 @@
+package sliding_window;
+
+import java.io.*;
+import java.util.*;
+public class BOJ_241226_ListOfUniqueNumbers {
+    static int N;
+    static int[] input;
+
+    static void simulation(){
+        Deque<Integer> dq = new ArrayDeque<>();
+        boolean[] visited = new boolean[100010];
+
+        long answer = 0;
+
+        for (int i = 0; i < N; i++) {
+            int cur = input[i];
+
+            if(visited[cur]){
+                while(!dq.isEmpty()){
+                    int su = dq.pollFirst();
+                    if(su == cur) break;
+                    visited[su] = false;
+                }
+            }
+            else visited[cur] = true;
+
+            answer += (dq.size() + 1);
+            dq.add(cur);
+        }
+
+        System.out.println(answer);
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        input = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            input[i] = Integer.parseInt(st.nextToken());
+        }
+
+        //
+        simulation();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#272 


## 📝 문제 풀이 전략 및 실제 풀이 방법
### 투포인터
배열에 1,2,3 이렇게 있을때 맨 마지막 수 3을 항상 포함하는 가능한 연속된 수열의 갯수는 3개 입니다.(123,23,3) 이를 활용하여 큐에 하나씩 넣어가면서 큐의 size 를 정답에 더하는 식으로 구현해주었습니다. 

방문배열과 큐를 이용해서 입력 배열을 돌면서 큐에 하나씩 넣기 전에 방문이 되었다면, 큐의 맨 처음부터 중복된 수를 만날때까지 모두 빼줍니다.  그러고 나서 큐에 남아있는 사이즈와 새로 들어갈 수를 정답에 더하면 됩니다.

## 🧐 참고 사항
.

## 📄 Reference
.
