### PR TITLE
BOJ_250102_비슷한 단어 & BOJ_250103_계란으로 계란치기

### DIFF
--- a/hoo/2025/January/week1/Main_16987_계란으로계란치기.java
+++ b/hoo/2025/January/week1/Main_16987_계란으로계란치기.java
@@ -1,0 +1,59 @@
+package SSAFY.study.algo.week30s.week32;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main_16987_계란으로계란치기 {
+
+    static int N;
+    static int[][] eggs;
+    static int maxStrikeCount;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        doStrike(0, 0);
+        System.out.println(maxStrikeCount);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        eggs = new int[N][2];
+
+        StringTokenizer st;
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            eggs[i] = new int[] {Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())};    // 2번 인덱스는 계란이 깨졌는 지 여부 저장, 0이면 깨진 것 1이면 살아있는 것
+        }
+        maxStrikeCount = 0;
+    }
+
+    static void doStrike(int nowEgg, int strikeCount) {
+        if (nowEgg == N) return;    // 기저, 모든 계란에 대해 수행이 끝난 경우 바로 종료
+        if (eggs[nowEgg][0] == 0) { // 현재 손에 든 계란이 깨진 계란이면 다음 계란으로
+            doStrike(nowEgg+1, strikeCount);
+            return;
+        }
+
+        for (int i = 0; i < eggs.length; i++) {
+            if (i == nowEgg || eggs[i][0] == 0) continue;   // 현재 계란이나 이미 깨진 계란은 건너 뜀
+
+            int tempStrikeCount = strikeCount;
+            int prevNowEgg = eggs[nowEgg][0];   // 현재 손에 든 계란과 내려친 계란의 내려치기 전 내구도
+            int prevAnotherEgg = eggs[i][0];
+            eggs[nowEgg][0] = Math.max(eggs[nowEgg][0] - eggs[i][1], 0); // 계란으로 계란 친 후 남은 내구도 저장(0 이하로 내려가지 않게끔 처리)
+            eggs[i][0] = Math.max(eggs[i][0] - eggs[nowEgg][1], 0);
+            if (eggs[nowEgg][0] == 0) tempStrikeCount++;    // 깨진 계란 있으면 카운트
+            if (eggs[i][0] == 0) tempStrikeCount++;
+            maxStrikeCount = Math.max(maxStrikeCount, tempStrikeCount);
+
+            doStrike(nowEgg+1, tempStrikeCount);    // 현재 손에 든 계란 오른쪽의 계란에 대해 수행
+            eggs[nowEgg][0] = prevNowEgg;   // 깼던 계란 원상복귀
+            eggs[i][0] = prevAnotherEgg;
+        }
+    }
+
+}

--- a/hoo/2025/January/week1/Main_2607_비슷한단어.java
+++ b/hoo/2025/January/week1/Main_2607_비슷한단어.java
@@ -1,0 +1,56 @@
+package twentytwentyfive.january.week1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Main_2607_비슷한단어 {
+
+    static String[] words;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        findSimilarWords();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        words = new String[Integer.parseInt(br.readLine())];
+        for (int i = 0; i < words.length; i++) words[i] = br.readLine();
+    }
+
+    static void findSimilarWords() {
+        int similarCount = 0;
+        int[] wordCountsInFirstWord = countWordsInWord(0);
+
+        for (int i = 1; i < words.length; i++) {
+            if (Math.abs(words[i].length()-words[0].length()) > 1) continue;    // 길이 자체가 1넘게 차이나면 애초에 비슷한 단어가 아님
+            if (judgeIsSimilar(wordCountsInFirstWord, i)) {
+                similarCount++;
+//                System.out.println(words[i]);
+            }
+        }
+
+        System.out.println(similarCount);
+    }
+
+    static boolean judgeIsSimilar(int[] wordCountInFirstWord, int compareWordIndex) {
+        int[] wordCountsInCompareWord = countWordsInWord(compareWordIndex);
+        int sameCount = 0;
+        for (int i = 0; i < 26; i++) {
+            if (wordCountInFirstWord[i] > 0 && wordCountsInCompareWord[i] > 0) sameCount += Math.min(wordCountInFirstWord[i], wordCountsInCompareWord[i]);
+
+        }
+
+        return Math.abs(Math.max(words[0].length(), words[compareWordIndex].length()) - sameCount) <= 1;
+    }
+
+    static int[] countWordsInWord(int numberIndex) {
+        int[] wordCounts = new int[26]; // 첫 번째 단어에 들어있는 알파벳 개수 카운트해서 저장하는 배열
+        for (int i = 0; i < words[numberIndex].length(); i++) wordCounts[words[numberIndex].charAt(i) - 'A']++;
+
+        return wordCounts;
+    }
+
+}

--- a/hoo/2025/January/week1/Main_2607_비슷한단어.java
+++ b/hoo/2025/January/week1/Main_2607_비슷한단어.java
@@ -38,7 +38,7 @@ public class Main_2607_비슷한단어 {
     static boolean judgeIsSimilar(int[] wordCountInFirstWord, int compareWordIndex) {
         int[] wordCountsInCompareWord = countWordsInWord(compareWordIndex);
         int sameCount = 0;
-        for (int i = 0; i < 26; i++) {
+        for (int i = 0; i < 26; i++) {  // 둘 중 더 적은 개수를 같은 문자 개수에 더해줌
             if (wordCountInFirstWord[i] > 0 && wordCountsInCompareWord[i] > 0) sameCount += Math.min(wordCountInFirstWord[i], wordCountsInCompareWord[i]);
 
         }


### PR DESCRIPTION
## 🔍 개요
+ #282 
+ #283 

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 비슷한 단어
처음에 너무 어렵게 생각해서 망했습니다. 단어 별로 인덱스를 조정해가며 만약 서로 다른 문자를 가르키고 있을 때에, 각 단어의 인덱스를 따로 조정하는 식으로 하여 비교를 해줬는데요... 31퍼센트 쯤인가까지만 가고 틀렸습니다. 그냥 애초에 잘못풀고 있었다고 판단하고, 문제 자체가 시간도 널널해서 그냥 간단하게 배열 만들어서 같은 것만큼 카운트를 해주고, 그 차이가 1을 초과하는 지를 판별해줬습니다. 그랬더니 되네요...

---
+ 계계치
현재 고른 계란 제외 다른 계란 중 하나를 골라서 친다 -> dfs를 떠올렸습니다. 
문제에서는 계란이 깨져있는 지 아닌 지를 떠나 무조건적으로 순차적으로 계란을 손에 들기를 원했습니다. 하지만 이때 만약 손에 든 계란이 깨져있다면 넘어가라고 했으므로, 조건문을 통해 다음으로 넘어가는 처리를 따로 해주었습니다. 이외의 처리는 for문을 통해 순회하며 계란 하나를 골라 치고 재귀를 수행하는 방식으로 해주었습니다.

## 🧐 참고 사항
계계치 짜계치

## 📄 Reference
