### PR TITLE
BOJ_250107_전구와 스위치

### DIFF
--- a/hoo/2025/January/week2/Main_2138_전구와스위치.java
+++ b/hoo/2025/January/week2/Main_2138_전구와스위치.java
@@ -1,0 +1,65 @@
+package twentytwentyfive.january.week2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Main_2138_전구와스위치 {
+
+    static int N;
+    static int[] goalBulb;
+
+    public static void main(String[] args) throws IOException {
+        int[] initBulbs = init();
+        calcSwitchCount(initBulbs);
+    }
+
+    static int[] init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        int[] initBulbs = makeIntArrFromString(br.readLine());
+        goalBulb = makeIntArrFromString(br.readLine());
+
+        return initBulbs;
+    }
+
+    static int[] makeIntArrFromString(String inputString) { // 입력으로 주어진 문자열을 정수형 배열로 바꾸는 함수
+        int[] intArr = new int[inputString.length()];
+        for (int i = 0; i < inputString.length(); i++) intArr[i] = Integer.parseInt(String.valueOf(inputString.charAt(i)));
+
+        return intArr;
+    }
+
+    static void calcSwitchCount(int[] initBulbs) {
+        int[] copiedBulbs = Arrays.copyOf(initBulbs, initBulbs.length); // 나는 doSwitch 함수에서 양옆을 건드리는 게 아니라, 앞으로 연속된 3개를 건드리며 진행함. 그러므로 뒤의 스위치를 다시 조작하는 것은 불가능하므로, 첫 번째 스위치를 건드린 경우는 수동적으로 처리한 배열 하나를 더 두어 따로 처리해줘야 함.
+        copiedBulbs[0] = Math.abs(copiedBulbs[0]-1);
+        copiedBulbs[1] = Math.abs(copiedBulbs[1]-1);
+
+        int countInitBulbs = 0;
+        int countCopiedBulbs = 1;
+        for (int i = 0; i < N-1; i++) {   // 첫 번째 전구부터 끝 직전 전구까지 보며 안맞는 전구면 스위치 눌러주고 카운트+1해줌
+            if (initBulbs[i] != goalBulb[i]) {
+                initBulbs = doSwitch(initBulbs, i);
+                countInitBulbs++;
+            }
+            if (copiedBulbs[i] != goalBulb[i]) {
+                copiedBulbs = doSwitch(copiedBulbs, i);
+                countCopiedBulbs++;
+            }
+        }
+        if (initBulbs[N-1] != goalBulb[N-1]) countInitBulbs = -1;   // 각 시나리오대로 돌려봤는데 끝 전구가 같지 않다면, 끝 전구를 눌렀을 때 그 앞 전구까지 바뀌므로 goalBulbs처럼 만들 수가 없게 됨.
+        if (copiedBulbs[N-1] != goalBulb[N-1]) countCopiedBulbs = -1;
+
+        if (countInitBulbs == -1) System.out.println(countCopiedBulbs); // 둘 중 올바르지 않은 시나리오가 있다면 옳은 시나리오의 전구만 출력
+        else if (countCopiedBulbs == -1) System.out.println(countInitBulbs);
+        else System.out.println(Math.min(countInitBulbs, countCopiedBulbs));    // 둘 다 만들 수 있는 경우면 두 전구 시나리오 중 스위치 누른 횟수 더 적은 쪽의 횟수 출력
+    }
+
+    static int[] doSwitch(int[] bulbs, int index) {
+        for (int i = index; i < Math.min(index+3, bulbs.length); i++) bulbs[i] = Math.abs(bulbs[i] - 1);    // 현재 전구의 스위치를 눌렀으니까 연속된 세 개의 전구 상태 바꿔 줌
+
+        return bulbs;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #291 

## 📝 문제 풀이 전략 및 실제 풀이 방법
저는 사실 6개월 전에 푼 문제고, 기억이 남아있어서 풀이를 했지만 모르는 상태에서 풀어라고 하면 정말 어려울 것 같습니다. 우선 오늘 풀이는 떠올렸던 풀이가 아니라 풀이의 해설을 적어보겠습니다.

문제에서 제시한 것처럼 전구를 켰을 때 앞 전구, 뒷 전구가 모두 바뀐다면 그로 인해 앞 전구가 달라졌을 때 또 앞 전구로 가서 스위치를 눌러줘야 합니다. 이건 백트래킹을 통해 해결이 가능해보이나, 문제는 N의 최댓값이 10만이라는 겁니다. 그리하여 양 옆 스위치 상태를 바꿔주는 게 아닌 현재 전구부터 앞으로만 연속된 3개의 전구를 바꿔주는 형식으로의 전환을 해주었습니다. 쉽게 생각해보면 첫 번째 전구 앞에 0번째 전구가 생겼고, 그 전구부터의 진행으로 한다고 생각할 수 있습니다.

이제부터는 분기를 나눠줘야 합니다. 저희가 나눠줄 수 있는 분기는 (첫 번째와 두 번째 전구) 세트의 상태에 따른 분기입니다. 어차피 스위치는 첫 번째 스위치부터 눌러줄 것이므로 모양은 어떻게든 맞춰줄 수 있습니다. 하지만 앞서 언급한 두 개의 전구 세트 상태에 따라 횟수는 달라질 것입니다. 이 두 개 전구의 세트는 각각 값을 조정할 수는 없고, 0번째 전구의 스위치를 눌러 조절할 수 있습니다. 따라서 1. 원본 상태 그대로인 경우, 2. 두 개의 전구 세트 값을 모두 바꿔주는 경우 총 두 가지의 분기로 진행을 할 수 있습니다.

이를 통해 원본 전구 상태, 첫 두개 전구 세트 값을 바꾼 전구 상태 배열 두 개를 가지고 for문을 돌며, 현재 전구 상태가 목표 전구 상태와 다를 때마다 연속한 3개의 전구 상태를 바꿔주고 각각의 경우에 따라 카운트를 해주는 로직을 수행합니다. 이때 주의할 점은 마지막 전구는 로직을 수행하면 안된다는 것입니다. 마지막 전 전구까지만 로직을 수행한 후 마지막 전구는 목표 전구와 상태를 비교해줘야 합니다. 저희가 전환한 사고방식에 의하면 0번째 스위치가 생겼으므로 마지막 전구에서의 상황판단은 0번째 스위치로 앞당겨 수행하게 되었기 때문입니다.
마지막 전구의 상태가 목표 전구 상태와 같다면 동일하게 만든 게 되므로 카운트 값을 그대로 사용, 다르다면 이는 만드는 게 불가능한 경우임을 표시하기 위해 카운트 값을 -1로 수정해줍니다. 이리하여 각각의 카운트 값 중 -1이 아닌 카운트 값을 이용, 그 중 최소값을 출력해주어 문제를 해결했습니다.


## 🧐 참고 사항

## 📄 Reference
