### PR TITLE
BOJ_250107_전구와 스위치

### DIFF
--- a/hyun/1_January/BOJ_250107_전구와스위치.java
+++ b/hyun/1_January/BOJ_250107_전구와스위치.java
@@ -1,0 +1,74 @@
+package bfs;
+
+import java.io.*;
+import java.util.*;
+public class BOJ_250107_전구와스위치 {
+    static int N;
+    static String input;
+    static String target;
+    static int[] dx = {-1,0,1};
+    static class Node{
+        String num;
+        int cnt;
+        Node(String num, int cnt){
+            this.num = num;
+            this.cnt = cnt;
+        }
+    }
+
+    static String changeNum(String su, int i){
+        String changePart = "";
+        for (int k = 0; k < 3; k++) {
+            int nxtI = i + dx[k];
+            if(nxtI < 0 || nxtI >= N) continue;
+            if(su.charAt(nxtI)  == '0') changePart += "1";
+            else changePart += "0";
+        }
+
+        String result = "";
+        result += su.substring(0,i);
+        result += changePart;
+        if(i+2 < N) result += su.substring(i+2,N);
+        return result;
+    }
+
+    static void bfs(){
+        Queue<Node> q = new ArrayDeque<>();
+        Set<String> visited = new HashSet<>();
+//        boolean[] visited = new boolean[200010];
+
+        q.add(new Node(input,0));
+        visited.add(input);
+
+        while(!q.isEmpty()){
+            Node cur = q.poll();
+
+            if(cur.num.equals(target)){
+                System.out.println(cur.cnt);
+                return;
+            }
+
+            for (int i = 0; i < N; i++) {
+                String made = changeNum(cur.num, i);
+                if(visited.contains(made)) continue;
+
+                q.add(new Node(made, cur.cnt+1));
+                visited.add(made);
+            }
+        }
+
+        System.out.println(-1);
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+
+        input = br.readLine();
+        target = br.readLine();
+
+        bfs();
+
+
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#291 


## 📝 문제 풀이 전략 및 실제 풀이 방법
커밋에 올라온 코드는 BFS 로 풀었던 코드입니다. 처음에 N을 전구의 갯수가 아니라 입력받은 수 자체로 보아서 BFS 로 풀었습니다 하핫. 당연히 메모리 초과이구여 큐가 터집니다.
그러고 생각을 해보았으나 도저히 모르겠어서 풀이 검색했습니다. 블로그 링크 걸어두었습니다.

전체적인 로직은 후님과 똑같으나 다른점은 이분은 첫번째 전구를 켜주고, 꺼줌 2가지 상태에서 출발하여 앞의 연속 3개를 봐주는 것이 아닌 문제에서 주어진 대로 전,현재,뒤 이렇게 3개를 봐주었습니다. 

순회는 2번쨰 전구부터 순회하여 1번째 전구가 목표한 전구와 상태가 같다면 스위치를 바꾸지 않는 식으로 진행하였습니다. 이렇게 됬을때 첫번째 전구는 두번째 전구의 스위치를 누름 유무에 따라 최종 상태가 결정됩니다. 이를 활용하여 순회는 2번째 전구부터 N번째 전구까지 모두봐주었습니다.

## 🧐 참고 사항
그리디는 어려워잉

## 📄 Reference
[BOJ_전구와 스위치](https://sa11k.tistory.com/50)
.
