### PR TITLE
BOJ_250110_드래곤앤던전

### DIFF
--- a/hyun/1_January/BOJ_250110_드래곤앤던전.java
+++ b/hyun/1_January/BOJ_250110_드래곤앤던전.java
@@ -1,0 +1,66 @@
+package binary_search;
+
+import java.io.*;
+import java.util.*;
+public class BOJ_250110_드래곤앤던전 {
+    static int N,initAttack;
+    static int[][] map;
+
+    static boolean simulation(long maxLife){
+        //System.out.println(maxLife);
+        long life = maxLife;
+        long attack = initAttack;
+        for (int i = 0; i < N; i++) {
+            if(map[i][0] == 1) { // 몬스터
+                long mAttack = map[i][1];
+                long mLife = map[i][2];
+
+                long quotient = mLife / attack;
+                long remainder = mLife % attack;
+                if(remainder != 0) quotient++;
+
+                life -= (quotient-1) * mAttack;
+                if(life <= 0) return false;
+
+            }
+            else{ // 포션
+                attack += map[i][1];
+                life += map[i][2];
+
+                if(life > maxLife) life = maxLife;
+            }
+        }
+        return true;
+    }
+
+    static void binarySearch(){
+        long low = 0;
+        long high = Long.MAX_VALUE;
+
+        while(low + 1 < high){
+            long mid = (low+high) / 2; // 최대 생명력
+            if(!simulation(mid)) low = mid;
+            else high = mid;
+        }
+        System.out.println(high);
+
+    }
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        initAttack = Integer.parseInt(st.nextToken());
+        map = new int[N][3];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            map[i][0] = Integer.parseInt(st.nextToken());
+            map[i][1] = Integer.parseInt(st.nextToken());
+            map[i][2] = Integer.parseInt(st.nextToken());
+        }
+
+        binarySearch();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#299 


## 📝 문제 풀이 전략 및 실제 풀이 방법
### 이분탐색
low = 0, high = Long.MAX_VALUE 로 설정하여 이 값은 문제에서 구해야할 최소 생명력입니다. 이 최소 생명력을 가지고 1번 ~N번방까지 시뮬레이션을 돌려주었습니다. 이때, 시간초과가 발생했는데 반복문으로 몬스터를 죽이는 과정을 구현하는 것이 아닌 나누기로 1번만에 몬스터를 죽이는 과정을 구현하니 시간초과를 해결했습니다.

이렇게 풀고 시간이 494ms 가 나왔는데 다른 사람 풀이 중 이분 탐색을 사용하지 않고 시간을 저보다 단축하여 풀이한 것이 있어서 블로그 링크 첨부하겠습니닷 !

## 🧐 참고 사항
.

## 📄 Reference
[다른사람 풀이](https://velog.io/@solser12/%EB%B0%B1%EC%A4%80-16434-%EB%93%9C%EB%9E%98%EA%B3%A4-%EC%95%A4-%EB%8D%98%EC%A0%84-JAVA)

ex) [깃허브 이슈, PR 템플릿 작성 할 때 참고](https://soft.plusblog.co.kr/66)
