### PR TITLE
BOJ_2501119_가희와 키워드

### DIFF
--- a/hyun/1_January/BOJ_250119_가회와키워드.java
+++ b/hyun/1_January/BOJ_250119_가회와키워드.java
@@ -1,0 +1,40 @@
+package hash;
+
+import java.io.*;
+import java.util.*;
+public class BOJ_250119_가회와키워드 {
+    static int N,M;
+    static Set<String> original = new HashSet<>();
+    static Set<String> except = new HashSet<>();
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < N; i++) {
+            original.add(br.readLine());
+        }
+
+        int total = original.size();
+        for (int i = 0; i < M; i++) {
+            String[] input = br.readLine().split(",");
+            int cnt = 0;
+            for (int j = 0; j < input.length; j++) {
+                String cur = input[j];
+
+                if(!except.contains(cur) && original.contains(cur)){
+                    cnt++;
+                    except.add(cur);
+                }
+            }
+
+            total -= cnt;
+            sb.append(total).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}

--- a/hyun/1_January/BOJ_250119_가회와키워드2.java
+++ b/hyun/1_January/BOJ_250119_가회와키워드2.java
@@ -1,0 +1,41 @@
+package hash;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+
+public class BOJ_250119_가회와키워드2 {
+    static int N,M;
+    static Set<String> original = new HashSet<>();
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < N; i++) {
+            original.add(br.readLine());
+        }
+
+        for (int i = 0; i < M; i++) {
+            String[] input = br.readLine().split(",");
+            for (int j = 0; j < input.length; j++) {
+                String cur = input[j];
+
+                if(!original.contains(cur)) continue;
+                else {
+                    original.remove(cur);
+                }
+            }
+
+            sb.append(original.size()).append("\n");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#316 


## 📝 문제 풀이 전략 및 실제 풀이 방법
### remove X
입력 문자열을 original 이란 이름의 set 에 담고, 가희가 블로그에 적은 키워드들은 except 이란 이름의 set 에 별도로 관리해줍니다.
한줄마다 가희가 블로그에 적은 키워드들의 집합이 들어오면 새롭게 except 이라는 곳에 추가될때마다 갯수를 세주어 기존의 original size 에서 빼면 메모장에서 가희가 블로그에 적은 키워드들이 제외된 갯수와 동일합니다. 그 다음 키워드들의 집합이 들어올땐 직전 케이스에서 구했던 original size 를 그대로 들고가면서 정답을 구하면 됩니다.

이렇게 생각한 이유는단순히 remove 하지 않고 해볼까? remove 가 비용이 꽤나 컸던 것 같아서 ( 구체적 근거 없음 ;;;;;; 잘못됫지만서도 ^^ ) 구현해보았습니다

### remove O
가희가 블로그에 적은 키워드를 remove 를 통해 직접 지워줍니다.

### 결론
시간은 remove O 가 더 빠르다.
이유
1. except 를 관리하는 메모리가 더 들고 두개의 set 을 확인해줘야 한다.
2. remove를 하면 original 의 크기가 더 작아져서 contains 하는 속도가 갈수록 빨라진다.

입니다 ~!

## 🧐 참고 사항
.

## 📄 Reference
.
