### PR TITLE
PGMS_250121_년, 월, 성별 별 상품 구매 회원 수 구하기 & BOJ_250122_집 구하기

### DIFF
--- a/hoo/2025/January/week4/Main_13911_집구하기.java
+++ b/hoo/2025/January/week4/Main_13911_집구하기.java
@@ -1,0 +1,139 @@
+package twentytwentyfive.january.week4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main_13911_집구하기 {
+
+    static class Edge implements Comparable<Edge> {
+        int from;
+        int to;
+        int dist;
+
+        public Edge(int from, int to, int dist) {
+            this.from = from;
+            this.to = to;
+            this.dist = dist;
+        }
+
+        @Override
+        public int compareTo(Edge e) {
+            return this.dist - e.dist;
+        }
+    }
+
+    static int V, E;
+    static List<List<Edge>> edgeList;
+    static int M, x, S, y;  // M: 맥도날드 개수, x: 맥세권 조건 / S: 스타벅스 개수, y: 스세권 조건
+    static List<Integer> mcDonaldList, starbucksList;
+    static boolean[] isMcDonald, isStarbucks;   // 해당 노드가 맥도날드인 지 스타벅스인 지 여부 저장
+    static int[] mcDonaldDist, starbucksDist;    // 각 집에서 각 프랜차이즈까지의 거리
+
+
+    public static void main(String[] args) throws IOException {
+        init();
+        dijkstra(mcDonaldList, x, mcDonaldDist);
+        dijkstra(starbucksList, y, starbucksDist);
+
+        int minDist = Integer.MAX_VALUE;
+        for (int i = 1; i <= V; i++) {
+            if ((mcDonaldDist[i] != Integer.MAX_VALUE && starbucksDist[i] != Integer.MAX_VALUE) // 오버플로우 방지
+            && (mcDonaldDist[i] != 0 && starbucksDist[i] != 0)) minDist = Math.min(minDist, mcDonaldDist[i]+starbucksDist[i]); // 각 프랜차이즈가 위치한 곳은 집이 아님
+        }
+        System.out.println((minDist==Integer.MAX_VALUE)? -1:minDist);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        V = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+
+        edgeList = new ArrayList<>();
+        for (int i = 0; i <= V; i++) edgeList.add(new ArrayList<>());
+        int from, to, dist;
+        for (int i = 0; i < E; i++) {   // 간선 정보 저장
+            st = new StringTokenizer(br.readLine());
+            from = Integer.parseInt(st.nextToken());
+            to = Integer.parseInt(st.nextToken());
+            dist = Integer.parseInt(st.nextToken());
+            edgeList.get(from).add(new Edge(from, to, dist));
+            edgeList.get(to).add(new Edge(to, from, dist));
+        }
+
+        getInputFranchise(br, 'M');
+        getInputFranchise(br, 'S');
+
+        mcDonaldDist = new int[V+1];
+        int franchiseIndex = 0;
+        for (int i = 1; i <= V; i++) {
+            if (franchiseIndex < mcDonaldList.size() && i == mcDonaldList.get(franchiseIndex)) franchiseIndex++; // 맥도날드인 정점은 거리 0으로 그냥 두고
+            else mcDonaldDist[i] = Integer.MAX_VALUE; // 나머지 정점들은 최대값으로 갱신
+        }
+        starbucksDist = new int[V+1];
+        franchiseIndex = 0;
+        Arrays.fill(starbucksDist, Integer.MAX_VALUE);
+        for (int i = 1; i <= V; i++) {
+            if (franchiseIndex < starbucksList.size() && i == starbucksList.get(franchiseIndex)) franchiseIndex++; // 스타벅스인 정점은 거리 0으로 그냥 두고
+            else starbucksDist[i] = Integer.MAX_VALUE; // 나머지 정점들은 최대값으로 갱신
+        }
+    }
+
+    static void getInputFranchise(BufferedReader br, char mode) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        if (mode == 'M') {
+            M = Integer.parseInt(st.nextToken());
+            x = Integer.parseInt(st.nextToken());
+
+            mcDonaldList = new ArrayList<>();
+            isMcDonald = new boolean[V+1];
+            st = new StringTokenizer(br.readLine());
+            for (int i = 0; i < M; i++) {
+                mcDonaldList.add(Integer.parseInt(st.nextToken()));
+                isMcDonald[mcDonaldList.get(i)] = true;
+            }
+        } else {
+            S = Integer.parseInt(st.nextToken());
+            y = Integer.parseInt(st.nextToken());
+
+            starbucksList = new ArrayList<>();
+            isStarbucks = new boolean[V+1];
+            st = new StringTokenizer(br.readLine());
+            for (int i = 0; i < S; i++) {
+                starbucksList.add(Integer.parseInt(st.nextToken()));
+                isStarbucks[starbucksList.get(i)] = true;
+            }
+        }
+    }
+
+    static void dijkstra(List<Integer> startPoints, int limit, int[] dist) {
+        PriorityQueue<Edge> pq = new PriorityQueue<>();
+        boolean[] visited = new boolean[V + 1];
+
+        for (int start : startPoints) { // 각 프랜차이즈의 모든 시작점을 다 넣어 줌
+            dist[start] = 0;
+            pq.offer(new Edge(start, start, 0));
+        }
+
+        while (!pq.isEmpty()) {
+            Edge now = pq.poll();
+            int current = now.to;
+
+            if (visited[current]) continue; // 이미 다음 지점까지의 거리들을 탐색해본 곳이면 건너 뜀
+            visited[current] = true;    // 이 지점에서 다음 지점들을 방문했다는 의미로 여기서 방문 처리를 해줌
+
+            for (Edge next : edgeList.get(current)) {
+                if (visited[next.to]) continue;
+                if (dist[current] + next.dist > limit) continue;    // 거리 제한 넘어가면 건너 뜀
+
+                if (dist[next.to] > dist[current] + next.dist) {    // 거리 짧은 곳은 일단 pq에 넣어 줌
+                    dist[next.to] = dist[current] + next.dist;
+                    pq.offer(new Edge(current, next.to, dist[next.to]));
+                }
+            }
+        }
+    }
+
+}

--- a/hoo/2025/January/week4/PGMS_년월성별별상품구매회원수구하기.sql
+++ b/hoo/2025/January/week4/PGMS_년월성별별상품구매회원수구하기.sql
@@ -1,0 +1,8 @@
+-- 코드를 입력하세요
+select YEAR(sales_date) year, MONTH(sales_date) month, ui.gender gender, count(distinct ui.user_id) users# 먼저 join을 통해 각 주문의 유저 성별을 뽑아와준다
+from online_sale os
+join user_info ui
+on os.user_id = ui.user_id
+where ui.gender is not null
+group by year, month, gender
+order by year asc, month asc, gender asc;


### PR DESCRIPTION
## 🔍 개요
+ #322 
+ #323 

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 년, 월, 성별 별 상품 구매 회원 수 구하기
구하고자 하는 개수 카운트는 online_sale 테이블에 있습니다. 우선 주문을 한 유저의 정보를 알아오기 위해 online_sale과 user_info를 join하여 각 주문 별 유저의 성별을 조회해옵니다.
그 후 join을 통해 만든 테이블에서 YEAR(), MONTH() 함수를 이용해 연, 월 별로 조회를 하도록 하여 그 열을 기준으로 group by를 해줍니다. 그럼 년도와 월 별로 데이터가 묶이게 되고, 그 후 join을 통해 가져온 유저의 성별도 group by의 조건에 넣어줍니다. 그럼 연, 월, 성별 별로 group이 지어지고 그들을 기반으로 조회가 가능합니다. 여기에 마지막으로 각 group 별 유저 수를 count하여 조회해주면 됩니다. 여기서 주의할 점은 주문한 "회원의 수"를 구하는 것이므로, 여러 번 주문한 회원을 중복적으로 카운트하는 것을 방지하기 위해 distinct를 추가해주어야 합니다.
---
+ 집 구하기
틀렸습니다(3%) => 조건 해결 => 틀렸습니다(10%) => 조건 해결 => 시간 초과(13%) => 다익스트라 수행 방식의 수정(각 프랜차이즈 별로 한 번씩 다 돌기 -> 모든 지점 pq에 다 넣고 한 번에 수행) => 해결의 과정을 겪었습니다.
처음 한 생각은 모든 맥도날드, 스타벅스에서 출발해서 각 집까지의 최단거리를 저장해주는 식으로 모든 집에서 가장 가까운 각 프랜차이즈까지의 거리를 저장하자였습니다.
이를 위해 맥도날드, 스타벅스의 정보를 따로 저장하고 각 프랜차이즈 별 최단거리를 저장하는 배열을 따로 만들어 관리해주었습니다.
입력받은 각 프랜차이즈에서 출발하여 각 집까지의 최단거리를 갱신해주는 데는 다익스트라를 사용했습니다. 모든 맥도날드와 모든 스타벅스에 대해 따로 다익스트라를 한 번씩 수행해주었으며, 각 다익스트라에서는 한 번에 처음 pq에 모든 가게를 넣어주어 실행해주었습니다.(이 부분을 수정하기 전에는 for문을 순회하며 각 가게 별로 다익스트라를 한 번씩 도는 식으로 수행했는데, 시간초과가 발생했습니다.)
이후 저장된 각 맥도날드까지의 최단거리 배열과 각 스타벅스까지의 최단거리 배열을 순회합니다. 순회하며 한 집에서 출발했을 때 가장 가까운 각 프랜차이즈까지의 거리를 더해주어, 현재까지의 최솟값보다 작다면 갱신하는 식으로 최종 최솟값을 구해줍니다. 이때 순회하며 판별해줄 차례가 된 곳이 프랜차이즈가 위치한 곳이 아니어야 하며, 저는 최단 거리의 저장한 배열의 초기값을 Integer.MAX_VALUE로 지정해주었기에 오버플로우 방지를 위해 Integer.MAX_VALUE가 아니어야 한다는 조건을 추가해주었습니다.

## 🧐 참고 사항


## 📄 Reference
