### PR TITLE
PGMS_250124_다트 게임 & PGMS_250127_특정 조건을 만족하는 물고기별 수와 최대 길이 구하기

### DIFF
--- a/hoo/2025/January/week4/PGMS_250124_다트게임.java
+++ b/hoo/2025/January/week4/PGMS_250124_다트게임.java
@@ -1,0 +1,38 @@
+import java.util.*;
+
+class Solution {
+
+    public int solution(String dartResult) {
+        int answer = calcScore(dartResult);
+
+        return answer;
+    }
+
+    public int calcScore(String dartResult) {
+        int score = 0;
+        List<Integer> scoreList = new ArrayList<>();    // 계산된 점수들을 저장해둘 리스트
+        int tempScore = 0;
+        for (int i = 0; i < dartResult.length(); i++) {
+            if (dartResult.charAt(i) == '*' || dartResult.charAt(i) == '#') {   // 옵션을 계산해줄 차례인 경우
+                if (dartResult.charAt(i) == '*') {
+                    for (int j = 1; j <= Math.min(scoreList.size(), 2); j++) {  // 현재 점수와 이전 점수까지 두 배 처리
+                        scoreList.set(scoreList.size()-j, scoreList.get(scoreList.size()-j)*2);
+                    }
+                } else if (dartResult.charAt(i) == '#') scoreList.set(scoreList.size()-1, scoreList.get(scoreList.size()-1)*-1);    // 현재 점수 마이너스 처리
+            } else if (dartResult.charAt(i) == 'S' || dartResult.charAt(i) == 'D' || dartResult.charAt(i) == 'T') {
+                if (dartResult.charAt(i) == 'S') tempScore = tempScore;
+                else if (dartResult.charAt(i) == 'D') tempScore = (int) Math.pow(tempScore, 2);
+                else if (dartResult.charAt(i) == 'T') tempScore = (int) Math.pow(tempScore, 3);
+
+                scoreList.add(tempScore);
+                tempScore = 0;
+            } else tempScore = Integer.parseInt(String.valueOf(tempScore) + String.valueOf(dartResult.charAt(i)));
+            // System.out.println(scoreList);
+        }
+
+        for (int i = 0; i < scoreList.size(); i++) score += scoreList.get(i);
+
+        return score;
+    }
+
+}

--- a/hoo/2025/January/week5/PGMS_250127_특정조건을만족하는물고기별수와최대길이구하기.sql
+++ b/hoo/2025/January/week5/PGMS_250127_특정조건을만족하는물고기별수와최대길이구하기.sql
@@ -1,0 +1,8 @@
+-- 코드를 작성해주세요
+select count(*) fish_count, MAX(length) max_length, fish_type
+from fish_info
+group by fish_type
+having avg(case when length is null then 10
+          else length
+          end) >= 33
+order by fish_type;


### PR DESCRIPTION
## 🔍 개요
+ #329 

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 다트 게임
주어지는 문자열을 순회하며 조건문으로 S, D, T일 때와 *, #일 때, 숫자일 때의 경우를 나누어 처리해주었습니다. 각 S, D, T를 점수 입력의 끝으로 받아들이고 이들 입력이 주어질 때마다 점수 리스트에 저장해주었습니다. *, #의 경우 리스트에 저장돼있던 숫자에 각 옵션에 맞게 처리를 해주고 마지막에 리스트를 순회하며 모든 점수를 더해주어 정답을 구했습니다.
---
+ 특정 조건을 만족하는 물고기별 수와 최대 길이 구하기
물고기 종류 별 그룹화를 해야하는 것은 명확했으므로 group by fish_type을 수행해줍니다. 이때 조건이 평균이 33cm이상인 물고기들만 그룹화하는 것인데, 저는 그룹화 시 "~한 그룹만 그룹화 해서 보여줘" => having을 사용한다 라고 머리에 저장해두고 있어서 having을 사용했습니다.
having의 조건 작성이 조금 낯설텐데요, case when 절을 사용해주면 됩니다. select 절에서 사용했던 case when의 다른 절에서의 활용을 익힐 수 있는 문제였습니다.

## 🧐 참고 사항

## 📄 Reference
