### PR TITLE
BOJ_250128_줄세우기

### DIFF
--- a/hoo/2025/January/week5/Main_2631_줄세우기.java
+++ b/hoo/2025/January/week5/Main_2631_줄세우기.java
@@ -1,0 +1,37 @@
+package twentytwentyfive.january.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main_2631_줄세우기 {
+
+    static int N;
+    static int[] children;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        lineChildren();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        children = new int[N];
+        for (int i = 0; i < N; i++) children[i] = Integer.parseInt(br.readLine());
+    }
+
+    static void lineChildren() {
+        int maxInOrder = 0;   // 가장 길게 오름차순 정렬이 돼있는 학생들의 수
+        int[] inOrderCount = new int[N];
+        for (int i = 0; i < N; i++) {
+            inOrderCount[i] = 1;    // 일단 본인 포함해서 카운트할 거라 1로 초기화
+            for (int j = 0; j < i; j++) {
+                if (children[i] > children[j]) inOrderCount[i] = Math.max(inOrderCount[i], inOrderCount[j] + 1);    // 자신의 이전 순서 학생 발견되면, 그 학생의 값+1과 현재 자신의 값 중 큰 값으로 갱신
+            }
+            maxInOrder = Math.max(maxInOrder, inOrderCount[i]);
+        }
+        System.out.println(N-maxInOrder);   // 전체 학생 수에서 가장 길게 순서대로 배정이 된 학생들 수 빼주면 새로 정렬해줘야 하는 학생들 수가 나옴
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #334 

## 📝 문제 풀이 전략 및 실제 풀이 방법
이미 순서가 오름차순으로 정렬돼있는 학생들은 다시 배정해줄 필요가 없습니다. 그러므로 전체 학생 수에서 이미 오름차순으로 정렬돼있는 학생 수를 빼주어서 나온 학생의 수가, 다시 배정해줘야 하는 학생의 수가 될 것입니다.
이를 위해 이미 오름차순으로 서있는 학생들의 최대 수를 구해야 합니다. N이 200으로 충분히 작으므로 2중 for문을 이용, 탐색 순서가 된 학생의 이전 학생들을 탐색하며 현재 학생까지 최대로 오름차순 정렬된 카운트를 구해서 int[] 배열에 저장해줍니다. 이를 모든 학생에 대해 수행해주며 이 중에서도 최대인 값을 구해줍니다.
그 값이 주어진 학생들 중 오름차순으로 정렬된 가장 많은 학생 수이고, 그 학생 수를 전체 학생 수에서 빼주면 위치를 재배치 해줘야하는 학생의 수를 알 수 있게 됩니다.

## 🧐 참고 사항

## 📄 Reference
