### PR TITLE
Softeer_240205_함께하는 효도 & Softeer_240206_금고털이 & Softeer_240207_성적 평가

### DIFF
--- a/hoo/2025/February/week2/Softeer_240205_함께하는효도.java
+++ b/hoo/2025/February/week2/Softeer_240205_함께하는효도.java
@@ -1,0 +1,87 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int n, m;
+    static int[][] map;
+    static int maxCropCount;
+
+    public static void main(String[] args) throws Exception {
+        int[][] initFriendAxis = init();  // 입력받기
+
+        boolean[][] isMarked = new boolean[n][n];  // 각 시간 별로 친구들이 위치한 곳을 마크할 배열
+        int croppedCount = 0;  // 수확한 열매 개수
+        for (int i = 0; i < m; i++) {
+            isMarked[initFriendAxis[i][0]][initFriendAxis[i][1]] = true;
+            croppedCount += map[initFriendAxis[i][0]][initFriendAxis[i][1]];
+        }
+
+        doCrop(0, 0, croppedCount, initFriendAxis, isMarked);
+        System.out.println(maxCropCount);
+    }
+
+    static int[][] init() throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new int[n][n];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < n; j++) map[i][j] = Integer.parseInt(st.nextToken());
+        }
+        maxCropCount = 0;
+
+        int[][] friendAxis = new int[m][2];
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            friendAxis[i] = new int[] {Integer.parseInt(st.nextToken())-1, Integer.parseInt(st.nextToken())-1};
+        }
+
+        return friendAxis;
+    }
+
+    static void doCrop(int time, int friendIndex, int croppedCount, int[][] friendAxis, boolean[][] isMarked) {
+        int[] dirRow = new int[] {-1, 0, 1, 0};  // 상 우 하 좌
+        int[] dirCol = new int[] {0, 1, 0, -1};
+
+        if (time == 3) {  // 기저, 3초간 수확을 다 한 경우
+            maxCropCount = Math.max(maxCropCount, croppedCount);
+
+            return;
+        }
+
+        int[] nowFriend = friendAxis[friendIndex];
+        int nextFriendRow, nextFriendCol;
+        for (int d = 0; d < 4; d++) {
+            nextFriendRow = nowFriend[0] + dirRow[d];
+            nextFriendCol = nowFriend[1] + dirCol[d];
+            if (isOuted(nextFriendRow, nextFriendCol)) continue;  // 범위 밖이면 건너 뜀
+
+            friendAxis[friendIndex] = new int[] {nextFriendRow, nextFriendCol};  // 현재 움직일 친구가 위치한 좌표
+
+            boolean isAlreadyMarked = isMarked[nextFriendRow][nextFriendCol];  // 현재 친구 말고 다른 친구에 의해 수확이 됐던 곳인 지 체크, 재귀 진입 후 원상복구할 때 이 값이 true라면 isMarked의 해당 좌표 값 false로 원상복구 안함
+            int nextCropCount = croppedCount;
+            if (!isMarked[nextFriendRow][nextFriendCol]) nextCropCount += map[nextFriendRow][nextFriendCol];  // 이전에 수확된 적이 없던 좌표면 수확함
+            isMarked[nextFriendRow][nextFriendCol] = true;  // 수확했음을 표시
+
+            int nextTime = time;
+            int nextFriendIndex = friendIndex+1;
+            if (friendIndex == m-1) {  // 현재 친구가 마지막 친구면 시간 +1초, 처음 친구로 인덱스 설정
+                nextTime++;
+                nextFriendIndex = 0;
+            }
+
+            doCrop(nextTime, nextFriendIndex, nextCropCount, friendAxis, isMarked);  // 재귀 들어감
+            friendAxis[friendIndex] = new int[] {nowFriend[0], nowFriend[1]};  // 원상복구
+            if (!isAlreadyMarked) isMarked[nextFriendRow][nextFriendCol] = false;  // 현재 학생 말고 다른 학생이 방문해서 수확했던 곳이라면 false로 되돌리지 않음
+        }
+    }
+
+    static boolean isOuted(int row, int col) {
+        if ((0 <= row && row < n) && (0 <= col && col < n)) return false;
+        return true;
+    }
+
+}

--- a/hoo/2025/February/week2/Softeer_240206_금고털이.java
+++ b/hoo/2025/February/week2/Softeer_240206_금고털이.java
@@ -1,0 +1,66 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int W, N;
+    // static int[][] jewels;
+    static PriorityQueue<int[]> jewels;
+
+    public static void main(String[] args) throws Exception {
+        init();
+        calcMaxCost();
+    }
+
+    static void init() throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        W = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+
+        // jewels = new int[N][2];
+        jewels = new PriorityQueue<>(new Comparator<int[]>() {
+            @Override
+            public int compare(int[] j1, int[] j2) {  // 무게 당 가격 기준 내림차순 정렬
+                return j2[1] - j1[1];
+            }
+        });
+        // for (int i = 0; i < N; i++) {
+        //     st = new StringTokenizer(br.readLine());
+        //     jewels[i] = new int[] {Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())};
+        // }
+        // Arrays.sort(jewels, new Comparator<int[]>() {
+        //     @Override
+        //     public int compare(int[] j1, int[] j2) {  // 무게 당 가격 기준 내림차순 정렬
+        //         return j2[1] - j1[1];
+        //     }
+        // });
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            jewels.offer(new int[] {Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())});
+        }
+    }
+
+    static void calcMaxCost() {
+        int totalWeight = 0;  // 현재까지 담은 보석의 무게
+        int totalCost = 0;  // 현재까지 담은 보석의 가격
+
+        // for (int[] j : jewels) {
+        int[] j;
+        while (!jewels.isEmpty()) {
+            j = jewels.poll();
+            // System.out.println(totalWeight);
+            // System.out.println(totalCost);
+            if (j[0] + totalWeight <= W) {
+                totalWeight += j[0];
+                totalCost += (j[1]*j[0]);
+            } else {
+                totalCost += ( j[1] * (W - totalWeight) );  // 남은 무게만큼 담음
+                break;
+            }
+        }
+
+        System.out.println(totalCost);
+    }
+
+}

--- a/hoo/2025/February/week2/Softeer_250207_성적평가.java
+++ b/hoo/2025/February/week2/Softeer_250207_성적평가.java
@@ -1,0 +1,62 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        calcRank(br, N);
+    }
+
+    static void calcRank(BufferedReader br, int N) throws Exception {
+        PriorityQueue<int[]> scores = new PriorityQueue<>(new Comparator<int[]>() {
+            @Override
+            public int compare(int[] i1, int[] i2) { // 점수(인덱스 0) 기준 내림차순 정렬
+                return i2[0] - i1[0];
+            }
+        });
+        int[] totalScore = new int[N];  // 참가자들의 총 점수
+
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+        int[] participantRanks = new int[N];  // 한 대회에 대한 참가자들의 등수
+        for (int i = 0; i < 3; i++) { // 3개의 대회에 대해
+            st = new StringTokenizer(br.readLine());
+            int participantNumber = 0; // 참가자 번호
+            for (int j = 0; j < N; j++) scores.offer(new int[] {Integer.parseInt(st.nextToken()), participantNumber++});  // 각 참가자들 정보 pq에 삽입
+
+            sb = getParticipantRank(sb, N, scores, participantRanks, totalScore);
+        }
+
+        for (int i = 0; i < N; i++) scores.offer(new int[] {totalScore[i], i}); // 총 점수 기반 등수도 구해주기
+        sb = getParticipantRank(sb, N, scores, participantRanks, totalScore);
+
+        System.out.println(sb);
+    }
+
+    static StringBuilder getParticipantRank(StringBuilder sb, int N, PriorityQueue<int[]> scores, int[] participantRanks, int[] totalScore) {
+        int rank = 0;
+        int prevScore = 0;  // 이전 참가자의 점수
+        int sameRankCount = 1;  // 동점자 수
+        int[] participant; // 각 참가자의 점수와 번호를 저장하는 배열
+        for (int j = 0; j < N; j++) { // 각 참가자들의 순위 저장
+            participant = scores.poll();
+            if (participant[0] == prevScore) {  // 동점인 경우
+                participantRanks[participant[1]] = rank;
+                sameRankCount++;
+            } else {
+                rank += sameRankCount;
+                participantRanks[participant[1]] = rank;
+                prevScore = participant[0];  // 이전 점수 갱신
+                sameRankCount = 1;  // 동점자 수 초기화
+            }
+            totalScore[participant[1]] += participant[0];  // 총 점수에도 합해줌
+        }
+        for (int j = 0; j < N; j++) sb.append(participantRanks[j]).append(" ");
+        sb.append("\n");
+
+        return sb;
+    }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #347 

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 함께하는 효도
재귀로 해결했습니다. 재귀함수의 파라미터로는 시간, 위치를 옮겨줄 친구의 인덱스, 현재 시간의 친구들 위치를 저장한 배열, 방문한 곳을 체크한 배열을 줬습니다.
재귀마다 현재 위치를 옮겨줄 차례가 된 친구를 사방으로 옮겨주며, 수확하지 않았던 열매라면 수확을 해줍니다. 이후 재귀를 수행해주고 재귀가 종료된 뒤 원상복귀를 해줄 때 현재 친구가 아닌 이전 친구가 방문을 했던 곳인 지 여부를 따져주어, 현재 친구가 방문했던 곳일 경우에만 원상복귀를 해주었습니다.
---
+ 금고털이
문제 조건을 좀 헷갈렸습니다. 무게당 가격이라는 말이 주어지는 보석의 무게당 그 가치를 한다는 것인지, 1Kg당 그 가치라는 것인 지가 헷갈렸습니다. 그런데 예제를 보니 1Kg당 가격일 것 같았고, 거기에 더불어 보석을 쪼개서 넣을 수 있다는 말이 있었으므로 그냥 1Kg당 가치가 높은 보석을 순서대로 넣어주면 될 것이라고 판단했습니다.
그리하여 순서대로 입력받은 보석을 무게 당 가치 기준 정렬, W를 채울 때까지 반복했으나 처음에는 시간초과를 겪었습니다. 제한 시간이 2초에 주어진 N이 100만이라 int[] 배열에 저장하고 O(NlogN)의 시간복잡도를 가지는 Arrays.sort()를 수행해주었는데, 이게 2초를 아슬아슬하게 넘어갔습니다. 이를 PriorityQueue<int[]>로 변경하여 시간초과를 해결했습니다.
---
+ 성적 평가
각 대회 별로, 우선 순위 큐에 참가자의 점수와 참가자 번호를 담은 int[] 배열을 삽입하여 등수를 구해주었습니다.
특별한 풀이는 없지만 동점자 처리를 위해 이전 참가자의 점수와 임시 카운트를 저장하는 변수 등을 사용해서 변수 사용이 많아졌습니다. 각 대회별 등수와 최종 점수에서의 등수를 출력하는 로직이 겹쳐 함수화를 해주었습니다.

## 🧐 참고 사항

## 📄 Reference
