### PR TITLE
BOJ_250213_탑보기

### DIFF
--- a/hyun/2_Febraury/BOJ_250213_탑보기.java
+++ b/hyun/2_Febraury/BOJ_250213_탑보기.java
@@ -1,0 +1,66 @@
+package stack;
+
+import java.io.*;
+import java.util.*;
+public class BOJ_250213_탑보기 {
+    static int N;
+    static int[] input;
+    static int[][] answer;
+
+    static void getAnswer(int start, int end, int offset){
+        Stack<int[]> st = new Stack<>();
+        int i = start;
+
+        while(true){
+            if(st.isEmpty()){
+                st.add(new int[]{ input[i], i});
+                continue;
+            }
+
+            while(!st.isEmpty()){
+                if(st.peek()[0] <= input[i]) st.pop();
+                else break;
+            }
+
+            answer[i][0] += st.size();
+            if(!st.isEmpty()) {
+                if(Math.abs(i-answer[i][1]) > Math.abs(i-st.peek()[1])) answer[i][1] = st.peek()[1];
+                if(Math.abs(i-answer[i][1]) == Math.abs(i-st.peek()[1])) answer[i][1] = Math.min(answer[i][1], st.peek()[1]);
+            }
+            st.add(new int[]{ input[i], i});
+
+            if(i == end) break;
+            i += offset;
+        }
+    }
+
+    static void simulation(){
+
+        getAnswer(1,N,1);
+        getAnswer(N,1,-1);
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= N ; i++) {
+            if(answer[i][0] == 0) sb.append(0).append("\n");
+            else sb.append(answer[i][0]).append(" ").append(answer[i][1]).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+
+        input = new int[N+1];
+        answer = new int[N+1][2]; // ( 갯수, 가장 적은 번호 )
+        for (int i = 1; i <= N ; i++) {
+            input[i] = Integer.parseInt(st.nextToken());
+            answer[i][1] = Integer.MAX_VALUE;
+        }
+
+        simulation();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
#360 


## 📝 문제 풀이 전략 및 실제 풀이 방법
스택 으로 풀었습니당
스택에 현재 건물을 담다가 만약 스택의 탑보다 현재 건물의 높이가 더 높다면 이는 현재 건물이 보지 못하는 건물이 존재하므로 볼 수 잇는 건물을 만날때까지 스택에서 빼주었습니다. 이렇게 다 빼고 나면 현재 건물이 볼 수 있는 건물만 남게 되어 정답에 갱신해주었습니다.

다만 현재 건물 기준으로 왼쪽, 오른쪽 방향에 있는 건물들을 봐줘야 하기 때문에 1번 ~ N번 건물 의 흐름 하나와 N번 ~ 1번 건물의 흐름을 봐주는 총 두가지의 흐름을 봐주어야 했습니다.

이렇게 인덱스의 증감만 다르고 나머지 부분의 코드는 똑같기 때문에 함수 하나로 모듈화를 시켰습니다. 변수는 start, end, offset 값을 주어 1번 ~ N번 건물을 봐줄땐 start = 1, end = N , offset = +1 로 해주었습니다.

## 🧐 참고 사항
.

## 📄 Reference
.
