### PR TITLE
PGMS_250219_부서별 평균 연봉 조회하기 & BOJ_250220_모양 만들기

### DIFF
--- a/hoo/2025/February/week4/Main_16932_모양만들기.java
+++ b/hoo/2025/February/week4/Main_16932_모양만들기.java
@@ -1,0 +1,80 @@
+package twentytwentyfive.february.week4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main_16932_모양만들기 {
+
+    static int N, M;
+    static int[][] board;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        int maxArea = 0;
+        int round = 1; // 0번 라운드부터 시작해서 끝날 때까지 해당 라운드에서 방문했음을 표시할 때 사용하는 변수
+        int[][] isChecked = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (isChecked[i][j] != 0) continue; // 이미 그룹을 지어봤던 칸이면 실행 안함
+
+                if (board[i][j] == 1) maxArea = Math.max(maxArea, findMaxAfterChange(i, j, board[i][j], isChecked, round)); // 원래 값으로 탐색
+                else maxArea = Math.max(maxArea, findMaxAfterChange(i, j, Math.abs(board[i][j]-1), isChecked, round)); // 해당 칸 값 바꿔서 탐색
+                round++;
+            }
+        }
+
+        System.out.println(maxArea);
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        board = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) board[i][j] = Integer.parseInt(st.nextToken());
+        }
+    }
+
+    static int findMaxAfterChange(int startRow, int startCol,  int startValue, int[][] isChecked, int round) {
+        int area = 0;
+        Queue<int[]> q = new ArrayDeque<>();
+        q.offer(new int[] {startRow, startCol});
+        isChecked[startRow][startCol] = round;
+
+        int[] dirRow = new int[] {-1, 0, 1, 0};
+        int[] dirCol = new int[] {0, 1, 0, -1};
+        int[] now;
+        while (!q.isEmpty()) {
+            now = q.poll();
+            area++;
+
+            int nextRow, nextCol;
+            for (int d = 0; d < 4; d++) {
+                nextRow = now[0] + dirRow[d];
+                nextCol = now[1] + dirCol[d];
+                if (isOuted(nextRow, nextCol) || isChecked[nextRow][nextCol] == round) continue;
+                if (board[nextRow][nextCol] != startValue) continue;
+
+                q.offer(new int[] {nextRow, nextCol});
+                isChecked[nextRow][nextCol] = round;
+            }
+        }
+
+        return area;
+    }
+
+    static boolean isOuted(int row, int col) {
+        if ((0 <= row && row < N) && (0 <= col && col < M)) return false;
+        return true;
+    }
+
+}

--- a/hoo/2025/February/week4/PGMS_250220_부서별평균연봉조회하기.sql
+++ b/hoo/2025/February/week4/PGMS_250220_부서별평균연봉조회하기.sql
@@ -1,0 +1,7 @@
+-- 코드를 작성해주세요
+select he.dept_id, hd.dept_name_en dept_name_en, round(avg(he.sal), 0) avg_sal
+from hr_employees he
+join hr_department hd
+on he.dept_id = hd.dept_id
+group by dept_id
+order by avg_sal desc;


### PR DESCRIPTION
## 🔍 개요
+ #373 
+ #374 

## 📝 문제 풀이 전략 및 실제 풀이 방법
+ 부서별 평균 연봉 조회하기
부서별 평균 연봉 -> employees 테이블에서 조회를 해야합니다. 그런데 부서별로 평균 연봉을 구해야 하므로, dept_id를 이용해 group지어줍니다. 이러면 부서별로 평균 연봉까지는 구해집니다.
최종 조회 결과에 부서의 영어 부서명을 포함해야하므로, 이때 department 테이블을 사용합니다. 앞서 조회한 테이블의 상태를 he라고 하고 department 테이블을 hd라고 한다면 he join hd on he.dept_id = hd.dept_id를 이용해 조인, hd에서 dept_name_en을 조회해주면 됩니다.

---
+ 모양 만들기
결국 최대로 이어진 1을 카운트하는 게 핵심이라고 생각했습니다. 그래서 뒤집는 것을 고려하지 않았을 때의 면적을 구하는 로직을 먼저 떠올려봤고, 1로 표기된 각 칸에서 bfs를 도는 로직을 사용하게 되었습니다.
이제 뒤집는 것을 고려해줘야 하는데요, 0인 칸에서 해당 칸을 1로 뒤집고 bfs를 수행해주면 되겠다고 판단했습니다. 이 상태에서 각 bfs에서 방문 배열을 만든다고 생각해보면 최대 시간복잡도가 1000*1000*1000*1000이므로 너무 큽니다. 그리하여 저번에 한 문제에서 배운 int[][] 배열에 각 라운드를 표기하는 하나의 방문배열을 이용했습니다.
88퍼센트 쯤에서 시간 초과를 겪었는데, 결국 원래 1이었던 칸들은 한 번만 체크해준다면 다음에는 해당 칸에서 체크를 시작할 필요가 없다는 생각이 들었습니다. 최대값이 갱신되는 경우는 결국 0인 칸을 1로 뒤집었을 때만 고려하면 되기 때문입니다. 그리하여 방문 체크를 하는 배열의 값이 초기값인 0이 아닌 경우에만 bfs를 수행하게끔하는 로직도 추가하여 해결했습니다.
풀긴했지만 이 풀이는 정말 원초적인 풀이법이라 시간이 오래걸린다는 단점이 있습니다.

## 🧐 참고 사항


## 📄 Reference
