### PR TITLE
BOJ_250221_징검다리 건너기(small)

### DIFF
--- a/hoo/2025/February/week4/Main_22869_징검다리건너기.java
+++ b/hoo/2025/February/week4/Main_22869_징검다리건너기.java
@@ -1,0 +1,47 @@
+package twentytwentyfive.february.week4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main_22869_징검다리건너기 {
+
+    static int N, K;
+    static int[] stones;
+
+    public static void main(String[] args) throws IOException {
+        init();
+        calcIfCan();
+    }
+
+    static void init() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        stones = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) stones[i] = Integer.parseInt(st.nextToken());
+    }
+
+    static void calcIfCan() {
+        int[] cost = new int[N];
+        cost[0] = 1;
+
+        for (int i = 0; i < N-1; i++) {
+            if (cost[i] == 0) continue; // 도달 불가능했던 돌은 건너 뜀
+
+            for (int j = i+1; j < N; j++) { // 우측에 있는 돌들에 대해 수행
+                int needEnergy = calcNeedEnergy(i, j);
+                if (needEnergy <= K) cost[j] = needEnergy; // k 이하의 에너지를 써서 이동 가능하면 갈 수 있음을 표시하기 위해 필요한 에너지를 j돌에 저장
+            }
+        }
+
+        System.out.println((cost[N-1]==0)? "NO":"YES");
+    }
+
+    static int calcNeedEnergy(int i, int j) { return (j - i) * ( 1 + Math.abs(stones[i] - stones[j]) ); }
+
+}


### PR DESCRIPTION
## 🔍 개요
+ #377 

## 📝 문제 풀이 전략 및 실제 풀이 방법
돌의 개수가 최대 5000개이고 각 움직임마다의 에너지 제한이 K이므로, 2중 for문을 이용해 갈 수 있는지 여부를 계산해주었습니다.
이때 메모이제이션을 사용했는데, 비용 계산용이 아니라 이동이 가능한지 여부를 저장했다고 생각하시면 될 것 같습니다. 이동이 불가능했던 돌을 제외하고는 모든 돌에서 다음 칸의 돌까지 이동하는 비용을 계산, 그 값이 K이하라면 값을 저장해주는 로직을 끝 돌까지 수행해줍니다.
이후 끝 돌의 값이 0이라면 도달 불가능했던 경우이므로 "NO"를 출력, 아니라면 "YES"를 출력해줍니다.
처음에 틀렸는데, 도달이 불가능했던 돌에서는 비용 계산을 해주지 않아야하는 조건을 빼고 로직을 수행해서였습니다.

## 🧐 참고 사항


## 📄 Reference
