### PR TITLE
PGMS_상품 별 오프라인 매출 구하기

### DIFF
--- a/hoo/2025/February/week5/PGMS_250228_상품별오프라인매출구하기.sql
+++ b/hoo/2025/February/week5/PGMS_250228_상품별오프라인매출구하기.sql
@@ -1,0 +1,6 @@
+select a.product_code, a.price * sum(b.sales_amount) as SALES
+from product as a
+join offline_sale as b
+on a.product_id = b.product_id
+group by a.product_code
+order by SALES desc, a.product_code asc;


### PR DESCRIPTION
## 🔍 개요
+ #390 

## 📝 문제 풀이 전략 및 실제 풀이 방법
상품 별 -> product 테이블에서 group by product_id를 이용해 상품별로 묶어주었습니다.
그 후 offline_sale 테이블과 product_id를 기준으로 조인하여, 각 프로덕트의 가격 * 주문 개수의 합을 출력해주었습니다.

## 🧐 참고 사항

## 📄 Reference